### PR TITLE
Support for intermediate SSL certificates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+  - Support intermediate SSL certificates.
+    (Rajiv Aaron Manglani <rajiv@brontes3d.com>)
+
   - SASL support (Previously released, but not advertised here)
     (Yann Kerherve <yann@cyberion.net>)
 

--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -118,8 +118,15 @@ sub set_config_sslcertificatefile {
     $self->{ssl_cert_file} = as_abs_path($val);
 }
 
+# mimicing Apache's SSLCertificateChainFile
+sub set_config_sslcertificatechainfile {
+    my ($self, $val) = @_;
+    $self->{ssl_cert_chain_file} = as_abs_path($val);
+}
+
 sub ssl_private_key_file { return $_[0]{ssl_private_key_file} }
 sub ssl_cert_file        { return $_[0]{ssl_cert_file}        }
+sub ssl_cert_chain_file  { return $_[0]{ssl_cert_chain_file}  }
 
 sub set_config_oldssl {
     my ($self, $val) = @_;

--- a/lib/DJabberd/Config.pod
+++ b/lib/DJabberd/Config.pod
@@ -44,6 +44,16 @@ certificate should be in PEM format, and will be presented to the
 clients who ask for TLS.  If it is not set, the server will not
 support TLS.
 
+=head2 SSLCertificateChainFile C</path/to/cert-chain.pem>
+
+Sets the path to the certificate chain file for the server. This is
+needed if the server certificate is signed by an intermediate
+certificate from a certificate authority. This file should be in PEM
+format. It must contain the server's certificate, followed by the
+intermediate certificates, then finally the root certificate.
+C<SSLCertificateKeyFile> and C<SSLCertificateFile> are required when
+using this option.
+
 =head2 OldSSL C<boolean>
 
 Defaults to off; if set, the server will also listen on port 5223, and

--- a/lib/DJabberd/Connection/OldSSLClientIn.pm
+++ b/lib/DJabberd/Connection/OldSSLClientIn.pm
@@ -35,6 +35,11 @@ sub new {
                                            &Net::SSLeay::FILETYPE_PEM);
     Net::SSLeay::die_if_ssl_error("certificate");
 
+    if ($server->ssl_cert_chain_file) {
+        Net::SSLeay::CTX_use_certificate_chain_file ($ctx, $server->ssl_cert_chain_file); # 'server-cert-chain.pem',
+        Net::SSLeay::die_if_ssl_error("certificate chain file");
+    }
+
 
     my $ssl = Net::SSLeay::new($ctx) or die_now("Failed to create SSL $!");
     $self->{ssl} = $ssl;

--- a/lib/DJabberd/Stanza/StartTLS.pm
+++ b/lib/DJabberd/Stanza/StartTLS.pm
@@ -37,6 +37,11 @@ sub process {
                                            &Net::SSLeay::FILETYPE_PEM);
     Net::SSLeay::die_if_ssl_error("certificate");
 
+    if ($conn->vhost->server->ssl_cert_chain_file) {
+        Net::SSLeay::CTX_use_certificate_chain_file ($ctx, $conn->vhost->server->ssl_cert_chain_file);
+        Net::SSLeay::die_if_ssl_error("certificate chain file");
+    }
+
 
     my $ssl = Net::SSLeay::new($ctx) or die_now("Failed to create SSL $!");
     $conn->{ssl} = $ssl;


### PR DESCRIPTION
Needed if the server's SSL certificate is signed by an intermediate certificate from a certificate authority.
