### PR TITLE
Add a prerequisite for Digest::SHA1 to correlate with t/lib/djabberd-test.pl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,7 @@ WriteMakefile(
                   'Net::SSLeay'                  => 0,
                   'Log::Log4perl'                => 0,
                   'Digest::HMAC_SHA1'            => 0,
+                  'Digest::SHA1'                 => 0,
                   'Unicode::Stringprep'          => 0,
               },
               clean      => { FILES => 't/log/*' },


### PR DESCRIPTION
It appears that an assumption was made such that Digest::SHA1 was part of core or similar, causing `make test` to fail.

I've patched `Makefile.PL` to add another entry to `PREREQ_PM` for the offending module.
