### PR TITLE
Use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
                   'Net::SSLeay'                  => 0,
                   'Log::Log4perl'                => 0,
                   'Digest::HMAC_SHA1'            => 0,
-                  'Digest::SHA1'                 => 0,
+                  'Digest::SHA'                  => 0,
                   'Unicode::Stringprep'          => 0,
               },
               clean      => { FILES => 't/log/*' },

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,10 @@ Section: perl
 Priority: optional
 Maintainer: Nick Andrew <nick@nick-andrew.net>
 Build-Depends: debhelper (>= 5)
-Build-Depends-Indep: perl (>= 5.6.10-12), liblog-log4perl-perl, libnet-dns-perl, libnet-ssleay-perl, libxml-sax-perl, libxml-libxml-perl, libdanga-socket-perl
+Build-Depends-Indep: perl (>= 5.6.10-12), liblog-log4perl-perl,
+ libnet-dns-perl, libnet-ssleay-perl, libxml-sax-perl,
+ libxml-libxml-perl, libdanga-socket-perl,
+ libunicode-stringprep-perl, libdigest-sha-perl
 Standards-Version: 3.8.0
 Homepage: http://danga.com/djabberd
 Vcs-Git: git://github.com/djabberd/DJabberd.git
@@ -29,7 +32,9 @@ Package: libdjabberd-perl
 Section: perl
 Priority: optional
 Architecture: all
-Depends: ${perl:Depends}, liblog-log4perl-perl, libnet-dns-perl, libnet-ssleay-perl, libxml-sax-perl, libxml-libxml-perl, libdanga-socket-perl
+Depends: ${perl:Depends}, liblog-log4perl-perl, libnet-dns-perl,
+ libnet-ssleay-perl, libxml-sax-perl, libxml-libxml-perl,
+  libdanga-socket-perl, libunicode-stringprep-perl, libdigest-sha-perl
 Suggests: openssl
 Description: Core Modules for DJabberd
  djabberd is a high-performance, scalable, extensible Jabber/XMPP

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -32,7 +32,7 @@ our $connection_id = 1;
 
 use XML::SAX ();
 use DJabberd::XMLParser;
-use Digest::SHA1 qw(sha1_hex);
+use Digest::SHA qw(sha1_hex);
 
 use DJabberd::SAXHandler;
 use DJabberd::JID;
@@ -276,7 +276,7 @@ sub version {
 
 sub stream_id {
     my $self = shift;
-    return $self->{stream_id} ||= Digest::SHA1::sha1_hex(rand() . rand() . rand());
+    return $self->{stream_id} ||= Digest::SHA::sha1_hex(rand() . rand() . rand());
 }
 
 # only use this run_hook_chain when

--- a/lib/DJabberd/Connection/ComponentIn.pm
+++ b/lib/DJabberd/Connection/ComponentIn.pm
@@ -21,7 +21,7 @@ package DJabberd::Connection::ComponentIn;
 use strict;
 use base 'DJabberd::Connection';
 use DJabberd::Log;
-use Digest::SHA1;
+use Digest::SHA;
 
 our $logger = DJabberd::Log->get_logger();
 
@@ -123,7 +123,7 @@ sub on_stanza_received {
         # FIXME: This probably doesn't handle escaping/encodings properly,
         #    so make sure the stream ID and secret are US-ASCII and don't use XML
         #    reserved characters!
-        my $correct = lc(Digest::SHA1::sha1_hex($self->stream_id.$self->{cmpnt_handler}->secret));
+        my $correct = lc(Digest::SHA::sha1_hex($self->stream_id.$self->{cmpnt_handler}->secret));
         
         if ($correct eq $innards) {
             # DJabberd::Connection is allergic to elements without 'to' attributes, so just send this raw

--- a/lib/DJabberd/Connection/ComponentOut.pm
+++ b/lib/DJabberd/Connection/ComponentOut.pm
@@ -21,7 +21,7 @@ package DJabberd::Connection::ComponentOut;
 use strict;
 use base 'DJabberd::Connection';
 use DJabberd::Log;
-use Digest::SHA1;
+use Digest::SHA;
 use Socket qw(PF_INET IPPROTO_TCP SOCK_STREAM);
 
 our $logger = DJabberd::Log->get_logger();
@@ -119,7 +119,7 @@ sub on_stream_start {
     my $correct_domain = $self->{vhost}->server_name;
 
     my $stream_id = $ss->id;
-    my $handshake = lc(Digest::SHA1::sha1_hex($stream_id.$self->{secret}));
+    my $handshake = lc(Digest::SHA::sha1_hex($stream_id.$self->{secret}));
 
     $logger->debug("I'm sending a handshake of $handshake based on a stream id of ".$stream_id." and the configured secret");
 

--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -3,7 +3,7 @@ use strict;
 use base qw(DJabberd::Stanza);
 use DJabberd::Util qw(exml);
 use DJabberd::Roster;
-use Digest::SHA1;
+use Digest::SHA;
 
 use DJabberd::Log;
 our $logger = DJabberd::Log->get_logger();
@@ -561,7 +561,7 @@ sub process_iq_setauth {
                                       if ($password && $password eq $good_password) {
                                           $accept->();
                                       } elsif ($digest) {
-                                          my $good_dig = lc(Digest::SHA1::sha1_hex($conn->{stream_id} . $good_password));
+                                          my $good_dig = lc(Digest::SHA::sha1_hex($conn->{stream_id} . $good_password));
                                           if ($good_dig eq $digest) {
                                               $accept->();
                                           } else {

--- a/lib/DJabberd/JID.pm
+++ b/lib/DJabberd/JID.pm
@@ -1,7 +1,7 @@
 package DJabberd::JID;
 use strict;
 use DJabberd::Util qw(exml);
-use Digest::SHA1;
+use Digest::SHA;
 
 # Configurable via 'CaseSensitive' config option
 our $CASE_SENSITIVE = 0;
@@ -171,7 +171,7 @@ sub as_bare_string {
 }
 
 sub rand_resource {
-    Digest::SHA1::sha1_hex(rand() . rand() . rand());
+    Digest::SHA::sha1_hex(rand() . rand() . rand());
 }
 
 1;

--- a/t/lib/djabberd-test.pl
+++ b/t/lib/djabberd-test.pl
@@ -711,7 +711,7 @@ sub login {
     if ($authreply =~ /\bpassword\b/) {
         $response = "<password>$password</password>";
     } elsif ($authreply =~ /\bdigest\b/) {
-        use Digest::SHA1 qw(sha1_hex);
+        use Digest::SHA qw(sha1_hex);
         my $dig = lc(sha1_hex($ss->id . $password));
         $response = "<digest>$dig</digest>";
     } else {


### PR DESCRIPTION
This commit makes DJabberd depend on Digest::SHA instead
of Digest::SHA1. Digest::SHA is in the perl core since 5.9.3
while Digest::SHA1 is not.

Futhermore Digest::SHA1 is not available in Debian wheezy
anymore.
