### PR TITLE
Add IPv6 listening support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ WriteMakefile(
                   'Digest::HMAC_SHA1'            => 0,
                   'Digest::SHA'                  => 0,
                   'Unicode::Stringprep'          => 0,
+                  'IO::Socket::INET6'            => 0,
               },
               clean      => { FILES => 't/log/*' },
               AUTHOR     => 'Brad Fitzpatrick <brad@danga.com>',

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper (>= 5)
 Build-Depends-Indep: perl (>= 5.6.10-12), liblog-log4perl-perl,
  libnet-dns-perl, libnet-ssleay-perl, libxml-sax-perl,
  libxml-libxml-perl, libdanga-socket-perl,
- libunicode-stringprep-perl, libdigest-sha-perl
+ libunicode-stringprep-perl, libdigest-sha-perl,
+ libio-socket-inet6-perl
 Standards-Version: 3.8.0
 Homepage: http://danga.com/djabberd
 Vcs-Git: git://github.com/djabberd/DJabberd.git
@@ -34,7 +35,8 @@ Priority: optional
 Architecture: all
 Depends: ${perl:Depends}, liblog-log4perl-perl, libnet-dns-perl,
  libnet-ssleay-perl, libxml-sax-perl, libxml-libxml-perl,
-  libdanga-socket-perl, libunicode-stringprep-perl, libdigest-sha-perl
+ libdanga-socket-perl, libunicode-stringprep-perl, libdigest-sha-perl,
+ libio-socket-inet6-perl
 Suggests: openssl
 Description: Core Modules for DJabberd
  djabberd is a high-performance, scalable, extensible Jabber/XMPP

--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -3,7 +3,7 @@
 use strict;
 use Carp;
 use Danga::Socket 1.51;
-use IO::Socket::INET;
+use IO::Socket::INET6;
 use IO::Socket::UNIX;
 use POSIX ();
 
@@ -314,14 +314,14 @@ sub _start_server {
                                         Listen => 10)
             or $logger->logdie("Error creating unix domain socket: $@\n");
     } else {
-        # assume it's a port if there's no colon
-        unless ($localaddr =~ /:/) {
-            $localaddr = "0.0.0.0:$localaddr";
+        # assume it's a port if there's no number after the (last) colon
+        unless ($localaddr =~ /:\d+$/) {
+            $localaddr = '[::]:'.$localaddr;
         }
 
         $logger->debug("Opening TCP listen socket on $localaddr");
 
-        $server = IO::Socket::INET->new(LocalAddr => $localaddr,
+        $server = IO::Socket::INET6->new(LocalAddr => $localaddr,
                                         Type      => SOCK_STREAM,
                                         Proto     => IPPROTO_TCP,
                                         Reuse     => 1,

--- a/lib/DJabberd/Util.pm
+++ b/lib/DJabberd/Util.pm
@@ -23,6 +23,10 @@ sub as_bind_addr {
     if ($val =~ /^(\d\d?\d?\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?:)?\d+$/ || ($val =~ m!^/! && -e $val)) {
         return $val;
     }
+    # looks like an IPv6 address
+    if ($val =~ /^\[[0-9a-f:]+\]:\d+$/) {
+        return $val;
+    }
     die "'$val' is not a valid bind address or port\n";
 }
 

--- a/t/admin-ipv6.t
+++ b/t/admin-ipv6.t
@@ -1,0 +1,47 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use IO::Socket::INET6;
+use Test::More tests => 3;
+use lib 't/lib';
+BEGIN {  $ENV{LOGLEVEL} ||= "FATAL" }
+BEGIN { require 'djabberd-test.pl' }
+
+my $adminhost = '::1';
+my $adminport = 23090;
+
+my $server = Test::DJabberd::Server->new(id => 1);
+$server->{adminport} = $adminport;
+$server->start();
+
+my $addr = '['.$adminhost.']:'.$adminport;
+
+select(undef, undef, undef, 0.25);
+
+my $sock = IO::Socket::INET6->new(
+    PeerAddr    => $adminhost,
+    PeerPort    => $adminport,
+    Timeout     => 1,
+) or die "Cannot connect to server " . $server->id . " ($addr)";
+diag('Connected to '.$addr);
+
+$sock->write("list vhosts\n");
+
+my $line = $sock->getline;
+like($line, qr/$server/, "Get the vhost back");
+
+like($sock->getline, qr/\./, "And a terminator" );
+
+$sock->write("counters\r\n");
+my $got_end = 0;
+my $buffer;
+while (my $line = $sock->getline) {
+    if ($line =~ /^\./) {
+        $got_end = 1;
+        last;
+    }
+    $buffer .= $line;
+}
+
+ok($got_end, "counters terminated in dot");

--- a/t/new-connects-ipv6.t
+++ b/t/new-connects-ipv6.t
@@ -1,0 +1,120 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use IO::Socket::INET6;
+use Devel::Peek;
+
+use Test::More 'no_plan';
+use lib 't/lib';
+require 'djabberd-test.pl';
+
+my $client_port = 11001;
+
+my $vhost = DJabberd::VHost->new(
+    server_name => 'jabber.example.com',
+    s2s         => 0,
+    plugins     =>
+    [
+        DJabberd::Authen::AllowedUsers->new(
+            policy          => 'deny',
+            allowedusers    => [qw(tester)],
+        ),
+        DJabberd::Authen::StaticPassword->new(
+            password => 'password',
+        ),
+        DJabberd::PresenceChecker::Local->new(),
+        DJabberd::Delivery::Local->new(),
+        DJabberd::Delivery::S2S->new(),
+        DJabberd::RosterStorage::InMemoryOnly->new(),
+    ],
+);
+
+my $server = DJabberd->new();
+
+$server->set_config_clientport($client_port);
+$server->set_config_serverport($client_port+1);
+
+$server->add_vhost($vhost);
+
+my $childpid = fork;
+if (!$childpid) {
+    $0 = "[djabberd]";
+    $server->run;
+    exit 0;
+}
+
+my $conn;
+
+foreach (1..3) {
+    print "Connecting...\n";
+    $conn = IO::Socket::INET6->new(
+        PeerAddr    => '::1',
+        PeerPort    => $client_port,
+        Timeout     => 1,
+    );
+    last if $conn;
+    sleep 1;
+}
+
+my $err = sub {
+    kill 9, $childpid;
+    die $_[0];
+};
+
+END {
+    kill 9, $childpid;
+}
+
+$err->("Can't connect to server") unless $conn;
+
+$conn->close;
+my $max_connects = 250;
+foreach my $n (1 .. $max_connects) {
+
+    my @events;
+    my ($handler, $p);
+    $handler = DJabberd::TestSAXHandler->new(\@events);
+    $p = DJabberd::XMLParser->new( Handler => $handler );
+
+    my $get_event = sub {
+        while (! @events) {
+            my $byte;
+            my $rv = sysread($conn, $byte, 1);
+            $p->parse_more($byte);
+        }
+        return shift @events;
+    };
+
+    my $get_stream_start = sub {
+        my $ev = $get_event->();
+        die unless $ev && $ev->isa('DJabberd::StreamStart');
+        return $ev;
+    };
+
+    diag("connect $n/$max_connects\n") if $n % 50 == 0;
+    $conn = IO::Socket::INET6->new(
+        PeerAddr    => '::1',
+        PeerPort    => $client_port,
+        Timeout     => 1,
+    );
+    
+    ok($conn,'got a socket');
+
+    print $conn qq{
+        <stream:stream
+          xmlns:stream='http://etherx.jabber.org/streams' to='jabber.example.com'
+          xmlns='jabber:client'>
+    };
+
+    my $ss = $get_stream_start->();
+    die unless $ss && $ss->id;
+
+    if ($n == 1) {
+        ok($ss, 'got a stream back');
+        ok($ss->id, 'got a stream id back');
+    }
+
+    $p->finish_push;
+    $conn->close;
+}


### PR DESCRIPTION
This commit adds IPv6 c2s (listening) support to the server using
IO::Socket::INET6 instead of IO::Socket::INET.

It also relaxes the IP(v4) check of DJabberd::Util::as_bind_addr
and introduces some new testcases for IPv6 connections.

This patch works for me, but has the drawback of requiring IPv6
capabilities even on hosts w/o (a need for) IPv6.

As IPv4 is facing its end-of-life I deem this is OK, but YMMV.

Please note that this PR only addresses reachability of the server using IPv6. It does not enable outgoing IPv6 connections. I'm working on that in another branch and will open another PR when it is fully working.
