### PR TITLE
Turn of warnings in DJabberd::SASL

### DIFF
--- a/lib/DJabberd/SASL.pm
+++ b/lib/DJabberd/SASL.pm
@@ -29,6 +29,7 @@ sub get_sasl_manager {
     my $class = $self->manager_class || $default;
 
     no strict 'refs';
+    no warnings;
     unless (defined %{"${class}::"}) {
         eval "use $class"; ## no critic
         die $@ if $@;


### PR DESCRIPTION
This commit turns of the warnings in DJabberd::SASL's get_sasl_manager.
In recent perl versions these warnings clutter the test output.

Since I'm not entirely sure if removing the defined stmt. will
silently break things I prefer to use the no warnings here.
