### PR TITLE
Improve debian package upgrades

### DIFF
--- a/debian/djabberd.init.d
+++ b/debian/djabberd.init.d
@@ -43,7 +43,7 @@ d_start() {
 d_stop() {
         start-stop-daemon --stop --quiet --pidfile $PIDFILE \
                 -d $HOME_DIR \
-                --name $NAME -- $OPTS
+                --name $NAME -- $OPTS || true
 }
 
 d_reload() {


### PR DESCRIPTION
This commit adresses an issue when upgrading the DJabberd
debian package. It the server is not running when
the upgrade is started it will fail due to a bad exit code
from the init script.

This commit makes sure as stopped server does not hinder
the upgrade process.
