### PR TITLE
Client Quirks Support - Miranda

### DIFF
--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -7,6 +7,7 @@ use Digest::SHA;
 
 use DJabberd::Log;
 our $logger = DJabberd::Log->get_logger();
+our $NULLID = 1;
 
 sub on_recv_from_client {
     my ($self, $conn) = @_;
@@ -45,7 +46,17 @@ sub process {
     # Trillian Jabber 3.1 is stupid and sends a lot of IQs (but non-important ones)
     # without ids.  If we respond to them (also without ids, or with id='', rather),
     # then Trillian crashes.  So let's just ignore them.
-    return unless defined($self->id) && length($self->id);
+    #
+    # ... unless this is Miranda because, at least up until 0.78, it sends
+    # roster updates without an id, oops.
+    unless (defined($self->id) && length($self->id)) {
+        if ($conn->client_has_quirk('SendsIqWithoutId')) {
+            $self->{attrs}{"{}id"} = 'null' . $NULLID++;
+        }
+        else {
+            return;
+        }
+    }
 
     $conn->vhost->run_hook_chain(phase    => "c2s-iq",
                                  args     => [ $self ],

--- a/lib/DJabberd/Presence.pm
+++ b/lib/DJabberd/Presence.pm
@@ -474,6 +474,16 @@ sub _process_outbound_available {
 
     if ($conn->is_initial_presence) {
         $conn->on_initial_presence;
+
+        # capture the client information for quirks detection, since the
+        # presence notification seems to be the cleanest way to find this.
+        foreach my $child ($self->children()) {
+            next unless ref $child;
+            next unless $child->element() eq '{http://jabber.org/protocol/caps}c';
+            my $client = $child->attr('{}node');
+            my $version = $child->attr('{}ver');
+            $conn->set_client_info($client, $version);
+        }
     }
 
     $self->broadcast_from($conn);


### PR DESCRIPTION
Deal with Miranda setting roster with a null id on the iq

One thing we ran into with inerop testing a few years ago, and it's been sitting around gathering dust in our local clone.
