### PR TITLE
Add IPv6 Server2Server support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,11 @@ WriteMakefile(
                   'Digest::SHA'                  => 0,
                   'Unicode::Stringprep'          => 0,
                   'IO::Socket::INET6'            => 0,
+                  'HTML::Entities'               => 0,
+              },
+              BUILD_REQUIRES => {
                   'Test::SharedFork'             => 0,
+                  'Test::TCP'                    => 0,
               },
               clean      => { FILES => 't/log/*' },
               AUTHOR     => 'Brad Fitzpatrick <brad@danga.com>',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ WriteMakefile(
                   'Digest::SHA'                  => 0,
                   'Unicode::Stringprep'          => 0,
                   'IO::Socket::INET6'            => 0,
+                  'Test::SharedFork'             => 0,
               },
               clean      => { FILES => 't/log/*' },
               AUTHOR     => 'Brad Fitzpatrick <brad@danga.com>',

--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -326,7 +326,7 @@ sub _start_server {
                                         Proto     => IPPROTO_TCP,
                                         Reuse     => 1,
                                         Listen    => 10 )
-            or $logger->logdie("Error creating socket: $@\n");
+            or $logger->logdie("Error creating socket at $localaddr: $@\n");
 
         my $success = $server->blocking(0);
 

--- a/lib/DJabberd/DNS.pm
+++ b/lib/DJabberd/DNS.pm
@@ -5,10 +5,12 @@ use fields (
             'hostname',
             'callback',
             'srv',
+            'a',
             'port',
             'recurse_count',
             'became_readable',  # bool
             'timed_out',        # bool
+            'nameserver',       # host:port, for testing
             );
 use Carp qw(croak);
 
@@ -17,6 +19,21 @@ our $logger = DJabberd::Log->get_logger();
 
 use Net::DNS;
 my $resolver    = Net::DNS::Resolver->new;
+
+sub set_nameserver {
+    my $ns = shift;
+    
+    # override default upstream nameserver for testing
+    if($ns && $ns =~ m/^(.*):(\d+)$/) {
+        my ($host, $port) = ($1, $2);
+        $resolver->nameservers($host);
+        $resolver->port($port);
+        
+        return 1;
+    }
+    
+    return;
+}
 
 sub srv {
     my ($class, %opts) = @_;
@@ -29,6 +46,7 @@ sub srv {
     my $callback = delete $opts{'callback'};
     my $service  = delete $opts{'service'};
     my $port     = delete $opts{'port'};
+    my $ns       = delete $opts{'nameserver'};
     my $recurse_count = delete($opts{'recurse_count'}) || 0;
     croak "unknown opts" if %opts;
 
@@ -44,11 +62,16 @@ sub srv {
             return;
         }
     }
+    
+    set_nameserver($ns);
 
     my $pkt = Net::DNS::Packet->new("$service.$hostname", "SRV", "IN");
 
     $logger->debug("pkt = $pkt");
     my $sock = $resolver->bgsend($pkt);
+    if(!$sock) {
+        croak 'bgsend failed w/ error: '.$resolver->errorstring;
+    }
     $logger->debug("sock = $sock");
     my $self = $class->SUPER::new($sock);
 
@@ -57,6 +80,8 @@ sub srv {
     $self->{srv}      = $service;
     $self->{port}     = $port;
     $self->{recurse_count} = $recurse_count;
+    
+    $self->{nameserver} = $ns;
 
     $self->{became_readable} = 0;
     $self->{timed_out}       = 0;
@@ -66,6 +91,59 @@ sub srv {
         return if $self->{became_readable};
         $self->{timed_out} = 1;
         $logger->debug("DNS 'SRV' lookup for '$hostname' timed out");
+        $callback->();
+        $self->close;
+    });
+
+    $self->watch_read(1);
+}
+
+sub a {
+    my ($class, %opts) = @_;
+
+    foreach (qw(hostname callback port)) {
+        croak("No '$_' field") unless $opts{$_};
+    }
+
+    my $hostname = delete $opts{'hostname'};
+    my $callback = delete $opts{'callback'};
+    my $port     = delete $opts{'port'};
+    my $ns       = delete $opts{'nameserver'};
+    my $recurse_count = delete($opts{'recurse_count'}) || 0;
+    croak "unknown opts" if %opts;
+
+    if ($hostname =~ m/^\d+\.\d+\.\d+\.\d+$/) {
+        # we already have the IP, lets not looking it up
+        $logger->debug("Skipping lookup for '$hostname', it is already the IP");
+        $callback->(DJabberd::IPEndPoint->new($hostname, $port));
+        return;
+    }
+    
+    set_nameserver($ns);
+
+    my $pkt = Net::DNS::Packet->new($hostname, "A", "IN");
+    my $sock = $resolver->bgsend($pkt);
+    if(!$sock) {
+        croak 'bgsend failed w/ error: '.$resolver->errorstring;
+    }
+    my $self = $class->SUPER::new($sock);
+
+    $self->{hostname} = $hostname;
+    $self->{callback} = $callback;
+    $self->{port}     = $port;
+    $self->{a}        = 1;
+    $self->{recurse_count} = $recurse_count;
+    
+    $self->{nameserver} = $ns;
+
+    $self->{became_readable} = 0;
+    $self->{timed_out}       = 0;
+
+    # TODO: make DNS timeout configurable, remove duplicate code
+    Danga::Socket->AddTimer(5.0, sub {
+        return if $self->{became_readable};
+        $self->{timed_out} = 1;
+        $logger->debug("DNS 'A' lookup for '$hostname' timed out");
         $callback->();
         $self->close;
     });
@@ -83,24 +161,32 @@ sub new {
     my $hostname = delete $opts{'hostname'};
     my $callback = delete $opts{'callback'};
     my $port     = delete $opts{'port'};
+    my $ns       = delete $opts{'nameserver'};
     my $recurse_count = delete($opts{'recurse_count'}) || 0;
     croak "unknown opts" if %opts;
 
-    if ($hostname =~/^\d+\.\d+\.\d+\.\d+$/) {
+    if ($hostname =~ m/^\d+\.\d+\.\d+\.\d+$/ || $hostname =~ m/^[A-F0-9:]+$/i) {
         # we already have the IP, lets not looking it up
         $logger->debug("Skipping lookup for '$hostname', it is already the IP");
         $callback->(DJabberd::IPEndPoint->new($hostname, $port));
         return;
     }
+    
+    set_nameserver($ns);
 
-
-    my $sock = $resolver->bgsend($hostname);
+    my $pkt = Net::DNS::Packet->new($hostname, 'AAAA', 'IN');
+    my $sock = $resolver->bgsend($pkt);
+    if(!$sock) {
+        croak 'bgsend failed w/ error: '.$resolver->errorstring;
+    }
     my $self = $class->SUPER::new($sock);
 
     $self->{hostname} = $hostname;
     $self->{callback} = $callback;
     $self->{port}     = $port;
     $self->{recurse_count} = $recurse_count;
+    
+    $self->{nameserver} = $ns;
 
     $self->{became_readable} = 0;
     $self->{timed_out}       = 0;
@@ -109,7 +195,7 @@ sub new {
     Danga::Socket->AddTimer(5.0, sub {
         return if $self->{became_readable};
         $self->{timed_out} = 1;
-        $logger->debug("DNS 'A' lookup for '$hostname' timed out");
+        $logger->debug("DNS 'AAAA' lookup for '$hostname' timed out");
         $callback->();
         $self->close;
     });
@@ -129,15 +215,18 @@ sub event_read {
     $self->{became_readable} = 1;
 
     if ($self->{srv}) {
-        $logger->debug("DNS socket $self->{sock} became readable for 'srv'");
+        $logger->debug("DNS socket $self->{sock} became readable for 'SRV'");
         return $self->event_read_srv;
-    } else {
-        $logger->debug("DNS socket $self->{sock} became readable for 'a'");
+    } elsif($self->{a}) {
+        $logger->debug("DNS socket $self->{sock} became readable for 'A'");
         return $self->event_read_a;
+    } else {
+        $logger->debug("DNS socket $self->{sock} became readable for 'AAAA'");
+        return $self->event_read_aaaa;
     }
 }
 
-sub event_read_a {
+sub event_read_aaaa {
     my $self = shift;
 
     my $sock = $self->{sock};
@@ -152,10 +241,70 @@ sub event_read_a {
             if ($ans->isa('Net::DNS::RR::CNAME')) {
                 if ($self->{recurse_count} < 5) {
                     $self->close;
-                    DJabberd::DNS->new(hostname => $ans->cname,
-                                       port     => $self->{port},
-                                       callback => $cb,
-                                       recurse_count => $self->{recurse_count}+1);
+                    DJabberd::DNS->new(
+                        hostname => $ans->cname,
+                        port     => $self->{port},
+                        callback => $cb,
+                        recurse_count => $self->{recurse_count}+1,
+                        nameserver => $self->{nameserver},
+                    );
+                }
+                else {
+                    # Too much recursion
+                    $logger->warn("Too much CNAME recursion while resolving ".$self->{hostname});
+                    $self->close;
+                    $cb->();
+                }
+            } elsif ($ans->isa("Net::DNS::RR::PTR")) {
+                $logger->debug("Ignoring RR response for $self->{hostname}");
+            }
+            else {
+                $cb->(DJabberd::IPEndPoint->new($ans->address, $self->{port}));
+            }
+            $self->close;
+            1;
+        };
+        if ($@) {
+            $self->close;
+            die "ERROR in DNS world: [$@]\n";
+        }
+        return if $rv;
+    }
+    
+    # no result, fallback to an A lookup
+    $self->close;
+    $logger->debug("DNS socket $sock for 'AAAA' had nothing, falling back to 'A' lookup");
+    DJabberd::DNS->a(
+        hostname => $self->{hostname},
+        port     => $self->{port},
+        callback => $cb,
+        nameserver => $self->{nameserver},
+    );
+    return;
+}
+
+sub event_read_a {
+    my $self = shift;
+
+    my $sock = $self->{sock};
+    my $cb   = $self->{callback};
+
+    my $packet = $resolver->bgread($sock);
+
+    my @answers = $packet->answer;
+
+    for my $ans (@answers) {
+        my $rv = eval {
+            if ($ans->isa('Net::DNS::RR::CNAME')) {
+                if ($self->{recurse_count} < 5) {
+                    $self->close;
+                    DJabberd::DNS->new(
+                        hostname => $ans->cname,
+                        port     => $self->{port},
+                        callback => $cb,
+                        recurse_count => $self->{recurse_count}+1,
+                        nameserver => $self->{nameserver},
+                    );
                 }
                 else {
                     # Too much recursion
@@ -197,33 +346,57 @@ sub event_read_srv {
     my @targets = sort {
         $a->priority <=> $b->priority ||
         $a->weight   <=> $b->weight
-    } grep { ref $_ eq "Net::DNS::RR::SRV" && $_->port } @ans;
+    } grep { ref $_ eq 'Net::DNS::RR::SRV' && $_->port } @ans;
 
     unless (@targets) {
         # no result, fallback to an A lookup
         $self->close;
         $logger->debug("DNS socket $sock for 'srv' had nothing, falling back to 'a' lookup");
-        DJabberd::DNS->new(hostname => $self->{hostname},
-                           port     => $self->{port},
-                           callback => $cb);
+        DJabberd::DNS->new(
+            hostname => $self->{hostname},
+            port     => $self->{port},
+            callback => $cb,
+            nameserver => $self->{nameserver},
+        );
         return;
     }
 
     # FIXME:  we only do the first target now.  should do a chain.
     $logger->debug("DNS socket $sock for 'srv' found stuff, now doing hostname lookup on " . $targets[0]->target);
-    DJabberd::DNS->new(hostname => $targets[0]->target,
-                       port     => $targets[0]->port,
-                       callback => $cb);
+    DJabberd::DNS->new(
+        hostname => $targets[0]->target,
+        port     => $targets[0]->port,
+        callback => $cb,
+        nameserver => $self->{nameserver},
+    );
     $self->close;
 }
 
 package DJabberd::IPEndPoint;
+use overload
+    '""' => \&as_string;
 sub new {
     my ($class, $addr, $port) = @_;
     return bless { addr => $addr, port => $port };
 }
-
+sub as_string {
+    if($_[0]->ver() == 4) {
+        return $_[0]{addr}.':'.$_[0]{port};
+    } else {
+        return '['.$_[0]{addr}.']:'.$_[0]{port};
+    }
+}
 sub addr { $_[0]{addr} }
 sub port { $_[0]{port} }
+sub ver  {
+    if(!defined($_[0]{ver})) {
+        if($_[0]{addr} =~ m/^\d+\.\d+\.\d+\.\d+$/) {
+            $_[0]{ver} = 4;
+        } else {
+            $_[0]{ver} = 6;
+        }
+    }
+    return $_[0]{ver};
+}
 
 1;

--- a/lib/DJabberd/Delivery/ComponentConnection.pm
+++ b/lib/DJabberd/Delivery/ComponentConnection.pm
@@ -36,7 +36,8 @@ use strict;
 use base qw(DJabberd::Delivery);
 use DJabberd::Connection::ComponentOut;
 use DJabberd::DNS;
-use Socket qw(PF_INET IPPROTO_TCP SOCK_STREAM TCP_NODELAY);
+use Socket qw(PF_INET PF_INET6 IPPROTO_TCP SOCK_STREAM AF_INET AF_INET6);
+use Socket6;
 
 our $logger = DJabberd::Log->get_logger();
 
@@ -55,36 +56,38 @@ sub set_config_secret {
 sub set_config_listenaddr {
     my ($self, $addr) = @_;
 
-    $addr = DJabberd::Util::as_bind_addr($addr);
-    
-    my ($ipaddr, $port) = split(/:/, $addr);
+    my $endpoint = $self->_get_ip_and_port
 
-    unless (defined($port)) {
-        $port = $ipaddr;
-        $ipaddr = "127.0.0.1";
-    }
-
-    $self->{listenaddr} = $ipaddr;
-    $self->{listenport} = $port;
-    
+    $self->{listenaddr} = $endpoint->addr;
+    $self->{listenport} = $endpoint->port;
 }
 
 sub set_config_remoteaddr {
     my ($self, $addr) = @_;
 
     # TODO: Make this support DNS lookups later
+    my $endpoint = $self->_get_ip_and_port
+    
+    $self->{remoteaddr} = $endpoint->addr;
+    $self->{remoteport} = $endpoint->port;
+}
+
+sub _addr_to_endpoint {
+    my ($self, $addr) = @_;
+    
     $addr = DJabberd::Util::as_bind_addr($addr);
-
-    my ($ipaddr, $port) = split(/:/, $addr);
-
-    unless (defined($port)) {
-        $port = $ipaddr;
-        $ipaddr = "127.0.0.1";
+    
+    my ($ipaddr, $port);
+    if($addr =~ m/^\[(.*)\]:(\d+)/) { # IPv6 + port
+        ($ipaddr, $port) = ($1, $2);
+    } elsif($addr =~ m/^(\d+\.\d+\.\d+\.\d+):(\d+)$/) { # IPv4 + port
+        ($ipaddr, $port) = ($1, $2);
+    } else {
+        $port = $addr;
+        $ipaddr = '::1';
     }
     
-    $self->{remoteaddr} = $ipaddr;
-    $self->{remoteport} = $port;
-
+    return DJabberd::IPEndPoint->new($ipaddr, $port);
 }
 
 sub finalize {
@@ -208,7 +211,7 @@ sub _start_listener {
         $logger->logdie("Error creating UNIX domain socket $bindaddr: $@") unless $server;
         $logger->info("Started listener for component ".$self->domain." on UNIX domain socket $bindaddr");
     } else {
-        $server = IO::Socket::INET->new(
+        $server = IO::Socket::INET6->new(
             LocalAddr => $bindaddr,
             Type      => SOCK_STREAM,
             Proto     => IPPROTO_TCP,

--- a/t/directed-presence-v6.t
+++ b/t/directed-presence-v6.t
@@ -1,0 +1,60 @@
+#!/usr/bin/perl
+use strict;
+use Test::More tests => 28;
+use lib 't/lib';
+require 'djabberd-test.pl';
+
+two_parties(sub {
+    my ($pa, $pb) = @_;
+    $pa->login;
+    $pb->login;
+    $pa->send_xml("<presence/>");
+    $pb->send_xml("<presence/>");
+
+    select(undef, undef, undef, 0.25);
+
+    pass "Test case where we send directed presence, then broadcast out unavailable";
+
+    my $e_pa_res = DJabberd::Util::exml($pa->resource);
+    my $e_pb_res = DJabberd::Util::exml($pb->resource);
+
+    $pa->send_xml(qq{<presence from="$pa/$e_pa_res" to="$pb/$e_pb_res"/>});
+
+    my $xml = $pb->recv_xml;
+
+    like($xml, qr{from=.$pa/testsuite});
+    like($xml, qr{to=.$pb/testsuite});
+    like($xml, qr{presence});
+
+    $pa->send_xml(qq{<presence><show>this should not go to B</show></presence>});
+    $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");
+    like($pb->recv_xml, qr/type=.chat.*Hello.*I am \Q$pa\E/, "pb got pa's message");
+
+    pass "Send a directed presence, then a directed unavailable, then verify we don't send broadcast out later";
+
+    $pb->send_xml(qq{<presence to="$pa/$e_pa_res"/>});  # adds $pa to $pb's directed list
+    $pb->send_xml(qq{<presence to="$pa/$e_pa_res" type="unavailable"/>}); # removes $pa from $pb's directed list
+    select undef, undef, undef, 0.25;
+
+    # $pa should get that $pb is available
+    $xml = $pa->recv_xml;
+    like($xml, qr{from=.$pb/testsuite});
+    like($xml, qr{to=.$pa/testsuite});
+    like($xml, qr{presence});
+
+    # $pa should get that $pb is unavailable
+    $xml = $pa->recv_xml;
+    like($xml, qr{type=.unavailable.});
+    like($xml, qr{from=.$pb/testsuite});
+    like($xml, qr{to=.$pa/testsuite});
+    like($xml, qr{presence});
+
+    # now verify the new presence broadcast doesn't incldue $pa
+    $pb->send_xml(qq{<presence from="$pb/$e_pb_res" type="unavailable"/>});
+    $pb->send_xml(qq{<message from="$pb/$e_pb_res" to="$pa/$e_pa_res">$pa should get me and not a unavailable packet</message>});
+
+    $xml = $pa->recv_xml;
+    like($xml, qr/should get me and not a unavailable packet/, "Make sure we get the message and not the prescence broadcast");
+
+},1);
+

--- a/t/dns.t
+++ b/t/dns.t
@@ -1,0 +1,161 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Danga::Socket;
+use Test::More tests => 12;
+use Test::SharedFork;
+use Test::TCP;
+use Net::DNS::Nameserver;
+use lib 't/lib';
+require 'djabberd-test.pl';
+
+my $ns_host = '127.0.0.1';
+my $ns_port = Test::TCP::empty_port();
+my $nameserver = $ns_host.q{:}.$ns_port;
+#print "Nameserver is at $nameserver\n";
+
+# Start Mock-Up DNS Server
+my $childpid_dns = fork;
+if(!$childpid_dns) {
+    my $reply_handler = sub {
+        my ($qname, $qclass, $qtype, $peerhost,$query,$conn) = @_;
+	my ($rcode, @ans, @auth, @add);
+        
+        #print 'Received query from '.$peerhost.' to '. $conn->{sockhost}. "\n";
+	#$query->print;
+
+	if ($qtype eq 'AAAA' && $qname eq 'www.ripe.net' ) {
+		my ($ttl, $rdata) = (3600, '2001:67c:2e8:22:0:0:c100:68b');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'A' && $qname eq 'www.ripe.net' ) {
+		my ($ttl, $rdata) = (3600, '193.0.6.139');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'SRV' && $qname eq '_xmpp-server._tcp.amessage.info' ) {
+		my ($ttl, $rdata) = (3600, '5 1 5269 s2s.amessage.eu');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'A' && $qname eq 's2s.amessage.eu' ) {
+		my ($ttl, $rdata) = (3600, '176.9.123.253');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'AAAA' && $qname eq 's2s.amessage.eu' ) {
+		my ($ttl, $rdata) = (3600, '2a01:4f8:151:82e3::2');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'SRV' && $qname eq '_xmpp-server._tcp.google.com' ) {
+		my ($ttl, $rdata) = (3600, '5 0 5269 xmpp-server.l.google.com');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+                ($ttl, $rdata) = (3600, '20 0 5269 alt1.xmpp-server.l.google.com');
+		$rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+                ($ttl, $rdata) = (3600, '20 0 5269 alt2.xmpp-server.l.google.com');
+		$rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+                ($ttl, $rdata) = (3600, '20 0 5269 alt3.xmpp-server.l.google.com');
+		$rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+                ($ttl, $rdata) = (3600, '20 0 5269 alt4.xmpp-server.l.google.com');
+		$rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+        } elsif ($qtype eq 'A' && $qname =~ m/xmpp-server.l.google.com$/ ) {
+		my ($ttl, $rdata) = (3600, '74.125.142.125');
+		my $rr = Net::DNS::RR->new("$qname $ttl $qclass $qtype $rdata");
+		push @ans, $rr;
+		$rcode = 'NOERROR';
+	} elsif ( $qname eq 'www.ripe.net' ) {
+		$rcode = 'NOERROR';
+	} else {
+		$rcode = 'NXDOMAIN';
+	}
+        
+        #print "Sending Reply for $qname/$qtype - $rcode - ".join(':', map { $_->string } @ans)."\n";
+
+	# mark the answer as authoritive (by setting the 'aa' flag
+	return ($rcode, \@ans, \@auth, \@add, { aa => 1 });
+    };
+    
+    my $ns = Net::DNS::Nameserver->new(
+        LocalPort       => $ns_port,
+        ReplyHandler    => $reply_handler,
+        Verbose         => 0,
+    );
+    
+    $ns->main_loop;
+    exit 0;
+}
+
+sleep 1;
+
+DJabberd::DNS->new(
+    hostname => 'www.ripe.net',
+    port     => 1,
+    callback => sub {
+        my $endpt = shift;
+        ok($endpt,'Got an Endpoint');
+        isa_ok($endpt,'DJabberd::IPEndPoint');
+        is($endpt->addr(),'2001:67c:2e8:22:0:0:c100:68b','Got the expected IPv6 address for www.ripe.net AAAA');
+    },
+    nameserver => $nameserver,
+);
+
+DJabberd::DNS->a(
+    hostname => 'www.ripe.net',
+    port     => 1,
+    callback => sub {
+        my $endpt = shift;
+        ok($endpt,'Got an Endpoint');
+        isa_ok($endpt,'DJabberd::IPEndPoint');
+        is($endpt->addr(),'193.0.6.139','Got the expected IPv4 address 193.0.6.139 for www.ripe.net A');
+    },
+    nameserver => $nameserver,
+);
+
+DJabberd::DNS->srv(
+    domain => 'amessage.info',
+    service => '_xmpp-server._tcp',
+    port     => 1,
+    callback => sub {
+        my $endpt = shift;
+        ok($endpt,'Got an Endpoint');
+        isa_ok($endpt,'DJabberd::IPEndPoint');
+        is($endpt->addr(),'2a01:4f8:151:82e3:0:0:0:2','Got the expected IPv6 address for _xmpp-server._tcp.amessage.info SRV');
+    },
+    nameserver => $nameserver,
+);
+
+DJabberd::DNS->srv(
+    domain => 'google.com',
+    service => '_xmpp-server._tcp',
+    port     => 1,
+    callback => sub {
+        my $endpt = shift;
+        ok($endpt,'Got an Endpoint');
+        isa_ok($endpt,'DJabberd::IPEndPoint');
+        like($endpt->addr(), qr/^\d+\.\d+\.\d+\.\d+$/,'Got the expected IPv4 address for _xmpp-server._tcp.google.com SRV');
+    },
+    nameserver => $nameserver,
+);
+
+# Start Event Socket
+my $childpid_sock = fork;
+if (!$childpid_sock) {
+    Danga::Socket->EventLoop();
+    exit 0;
+}
+
+sleep 2;
+
+END {
+    kill 9, $childpid_sock if $childpid_sock;
+    kill 9, $childpid_dns if $childpid_dns;
+}

--- a/t/lib/djabberd-test.pl
+++ b/t/lib/djabberd-test.pl
@@ -11,6 +11,7 @@ use DJabberd::TestSAXHandler;
 use DJabberd::RosterStorage::InMemoryOnly;
 use DJabberd::Util;
 use IO::Socket::UNIX;
+use IO::Socket::INET6;
 
 my $HAS_SASL;
 eval "use Authen::SASL 2.1402";
@@ -37,6 +38,7 @@ sub once_logged_in {
 
 sub two_parties {
     my $cb = shift;
+    my $ipv6 = shift || 0;
 
     if ($ENV{WILDFIRE_S2S}) {
         two_parties_wildfire_to_local($cb);
@@ -50,7 +52,7 @@ sub two_parties {
 
     two_parties_one_server($cb);
     sleep 1;
-    two_parties_s2s($cb);
+    two_parties_s2s($cb,1);
     sleep 1;
 }
 
@@ -113,9 +115,10 @@ sub two_parties_one_server {
 
 sub two_parties_s2s {
     my $cb = shift;
+    my $ipv6 = shift || 0;
 
-    my $server1 = Test::DJabberd::Server->new(id => 1);
-    my $server2 = Test::DJabberd::Server->new(id => 2);
+    my $server1 = Test::DJabberd::Server->new(id => 1, ipv6 => $ipv6, );
+    my $server2 = Test::DJabberd::Server->new(id => 2, ipv6 => $ipv6, );
     $server1->link_with($server2);
     $server2->link_with($server1);
     $server1->start;
@@ -202,7 +205,7 @@ sub new {
 
 sub peeraddr {
     my $self = shift;
-    return $self->{connect_ip} || ($self->{not_local} ? $self->{hostname} : "127.0.0.1");
+    return $self->{connect_ip} || ($self->{not_local} ? $self->{hostname} : ( $self->{ipv6} ? '::1' : '127.0.0.1'));
 }
 
 sub serverport {
@@ -549,7 +552,7 @@ sub connect {
                      $self->server->peeraddr,
                      $self->server->clientport);
         for (1..3) {
-            $sock = IO::Socket::INET->new(PeerAddr => $addr,
+            $sock = IO::Socket::INET6->new(PeerAddr => $addr,
                                           Timeout => 1);
             last if $sock;
             sleep 1;

--- a/t/lib/djabberd-test.pl
+++ b/t/lib/djabberd-test.pl
@@ -52,7 +52,7 @@ sub two_parties {
 
     two_parties_one_server($cb);
     sleep 1;
-    two_parties_s2s($cb,1);
+    two_parties_s2s($cb,$ipv6);
     sleep 1;
 }
 
@@ -286,18 +286,20 @@ sub start {
 
     if ($type eq "djabberd") {
         my $plugins = shift || ($PLUGIN_CB ? $PLUGIN_CB->($self) : $self->standard_plugins);
+        
         my $vhost = DJabberd::VHost->new(
-                                         server_name => $self->hostname,
-                                         s2s         => 1,
-                                         plugins     => $plugins,
-                                         );
-        my $server = DJabberd->new;
+            server_name => $self->hostname,
+            s2s         => 1,
+            plugins     => $plugins,
+        );
+        my $server = DJabberd->new();
+        
         $server->set_config_unixdomainsocket($self->{unixdomainsocket}) if $self->{unixdomainsocket};
 
         foreach my $peer (@{$self->{peers} || []}){
             $server->set_fake_s2s_peer($peer->hostname => DJabberd::IPEndPoint->new($peer->peeraddr, $peer->serverport));
             foreach my $subdomain (@SUBDOMAINS) {
-                $server->set_fake_s2s_peer($subdomain . '.' . $peer->hostname => DJabberd::IPEndPoint->new("127.0.0.1", $peer->serverport));
+                $server->set_fake_s2s_peer($subdomain . '.' . $peer->hostname => DJabberd::IPEndPoint->new($peer->peeraddr, $peer->serverport));
             }
         }
 


### PR DESCRIPTION
This commit adds experimental server2server support.

It will make DJabberd::DNS prefer AAAA records over A records
and implement IPv6 capabilities for dialback and outgoing
component connections.

There are also some new testcases, especially for DJabberd::DNS.

The DJabberd::DNS tests use a mock-up DNS server for reliable
and reproduceable DNS tests.

Please note that the whole patch is still very much experimental.

Please note that this PR is not meant to be merged as-is. I did open this PR to get this patch discussed/reviewed. It should be merged only after my other pending PRs have been merged. As soon as those get merged I'll rebase this one to get a clean history and adress any issues that may arise.
