### PR TITLE
Add iq:result handler

### DIFF
--- a/lib/DJabberd/Connection/ClientIn.pm
+++ b/lib/DJabberd/Connection/ClientIn.pm
@@ -10,6 +10,7 @@ use fields (
             'is_available',          # bool: is an "available resource"
             'directed_presence',     # the jids we have sent directed presence too
             'pend_in_subscriptions', # undef or arrayref of presence type='subscribe' packets to be redelivered when we become available
+	    'waiting_acks',          # arrayref of strings representing iq id we expect to receive result for
             );
 
 sub note_pend_in_subscription {
@@ -298,6 +299,21 @@ sub filter_incoming_client_builtin {
                                 $stanza->on_recv_from_client($self);
                             });
 
+}
+
+sub wait_for {
+    my ($self, $id) = @_;
+    push(@{$self->{waiting_acks} ||= []},$id);
+}
+sub waiting {
+    my $self = shift;
+    return @{$self->{waiting_acks} || []};
+}
+sub ack {
+    my ($self, $id) = @_;
+    if(ref $self->{waiting_acks}) {
+	$self->{waiting_acks} = [ grep {$_ ne $id} @{$self->{waiting_acks}} ];
+    }
 }
 
 1;

--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -39,6 +39,7 @@ my $iq_handler = {
     'get-{jabber:iq:register}query' => \&process_iq_getregister,
     'set-{jabber:iq:register}query' => \&process_iq_setregister,
     'set-{djabberd:test}query' => \&process_iq_set_djabberd_test,
+    'result-(BOGUS)' => \&process_iq_result,
 };
 
 # DO NOT OVERRIDE THIS
@@ -738,6 +739,17 @@ sub process_iq_set_djabberd_test {
     }
 
     $iq->send_result_raw("<unknown-command/>");
+}
+
+sub process_iq_result {
+    my ($conn, $iq) = @_;
+    for my $id ($conn->waiting) {
+	if ($iq->id eq $id) {
+	    $conn->ack($id);
+	    return 1;
+	}
+    }
+    return 0;
 }
 
 sub id {

--- a/lib/DJabberd/Stanza/StartTLS.pm
+++ b/lib/DJabberd/Stanza/StartTLS.pm
@@ -29,7 +29,7 @@ sub process {
         and Net::SSLeay::die_if_ssl_error("ssl ctx set options");
 
     # Following will ask password unless private key is not encrypted
-    Net::SSLeay::CTX_use_RSAPrivateKey_file ($ctx,  $conn->vhost->server->ssl_private_key_file,
+    Net::SSLeay::CTX_use_PrivateKey_file ($ctx,  $conn->vhost->server->ssl_private_key_file,
                                              &Net::SSLeay::FILETYPE_PEM);
     Net::SSLeay::die_if_ssl_error("private key");
 

--- a/lib/DJabberd/VHost.pm
+++ b/lib/DJabberd/VHost.pm
@@ -471,6 +471,7 @@ sub roster_push {
         my $id = $c->new_iq_id;
         my $iq = "<iq to='" . $c->bound_jid->as_string_exml . "' type='set' id='$id'>$xml</iq>";
         $c->xmllog->info($iq);
+	$c->wait_for($id);
         $c->write(\$iq);
     }
 }


### PR DESCRIPTION
Hi,
This is simple handler for iq result returned to set issued by roster_push in VHost. Waiting queue is per-connection hence should be fairly safe to ignore growing queue - when client doesn't ack iqs connection is going to be teared soon anyway.
    \* Add pending iq result queue to ClientIn Connection
    \* Add iq result handler to IQ
    \* Enqueue expected iq result for roster_push in VHost
