### PR TITLE
Test fix. The order of tag attributes changes and throw errors.

### DIFF
--- a/t/disco.t
+++ b/t/disco.t
@@ -17,7 +17,7 @@ once_logged_in(sub {
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>");
 
-    like($pa->recv_xml, qr{<identity type='im' category='server' name='djabberd'/>}, "Say we are a server");
+    like($pa->recv_xml, qr{<identity (?=.*type='im')(?=.*category='server')(?=.*name='djabberd').*/>}, "Say we are a server");
 
     $pa->send_xml(qq{<iq type='get'
                          from='$pa/$res'


### PR DESCRIPTION
Hello,
Im having trouble passing tests. After analyse i noticed the order of tag <iq> changes. Find the error below.
For the solution i modified t/disco.t and made it match the tags in any order.
Please accept the pull request if you have interest.

Here is the error:
# Failed test 'Say we are a server'
# at t/disco.t line 20.
# '<iq from='s1.example.com' type='result' to='partya@s1.example.com/testsuite_with_gibberish:&#x27;&#x22;' id='info1'><query xmlns='http://jabber.org/protocol/disco#info'><identity type='im' name='djabberd' category='server'/><feature var='http://jabber.org/protocol/disco#info'/></query></iq>'
# doesn't match '(?^:<identity type='im' category='server' name='djabberd'/>)'
# Looks like you failed 1 test of 2.
