### PR TITLE
Bump tls implementation to align with latest standards

### DIFF
--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -146,6 +146,18 @@ sub set_config_sslcertificatechainfile {
     $self->{ssl_cert_chain_file} = as_abs_path($val);
 }
 
+sub set_config_sslcacertificatefile {
+    my ($self, $val) = @_;
+    $self->{ssl_ca_cert_file} = as_abs_path($val);
+}
+
+sub set_config_sslcacertificatepath {
+    my ($self, $val) = @_;
+    die "Path '$val' isn't absolute" unless $val =~ m!^/!;
+    die "Path '$val' doesn't exist" unless -d $val;
+    $self->{ssl_ca_cert_path} = $val;
+}
+
 sub set_config_sslciphersuite {
     my ($self, $val) = @_;
     $self->{ssl_cipher_list} = $val;
@@ -164,6 +176,8 @@ sub set_config_sslecdhcurve {
 sub ssl_private_key_file { return $_[0]{ssl_private_key_file} }
 sub ssl_cert_file        { return $_[0]{ssl_cert_file}        }
 sub ssl_cert_chain_file  { return $_[0]{ssl_cert_chain_file}  }
+sub ssl_ca_cert_file     { return $_[0]{ssl_ca_cert_file}||'' }
+sub ssl_ca_cert_path     { return $_[0]{ssl_ca_cert_path}||'' }
 sub ssl_cipher_list      { return $_[0]{ssl_cipher_list}      }
 sub ssl_dhparam_file     { return $_[0]{ssl_dhparam_file}     }
 sub ssl_ecdh_curve       { return $_[0]{ssl_ecdh_curve}       }

--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -146,9 +146,27 @@ sub set_config_sslcertificatechainfile {
     $self->{ssl_cert_chain_file} = as_abs_path($val);
 }
 
+sub set_config_sslciphersuite {
+    my ($self, $val) = @_;
+    $self->{ssl_cipher_list} = $val;
+}
+
+sub set_config_ssldhparamfile {
+    my ($self, $val) = @_;
+    $self->{ssl_dhparam_file} = as_abs_path($val);
+}
+
+sub set_config_sslecdhcurve {
+    my ($self, $val) = @_;
+    $self->{ssl_ecdh_curve} = $val;
+}
+
 sub ssl_private_key_file { return $_[0]{ssl_private_key_file} }
 sub ssl_cert_file        { return $_[0]{ssl_cert_file}        }
 sub ssl_cert_chain_file  { return $_[0]{ssl_cert_chain_file}  }
+sub ssl_cipher_list      { return $_[0]{ssl_cipher_list}      }
+sub ssl_dhparam_file     { return $_[0]{ssl_dhparam_file}     }
+sub ssl_ecdh_curve       { return $_[0]{ssl_ecdh_curve}       }
 
 sub set_config_oldssl {
     my ($self, $val) = @_;

--- a/lib/DJabberd/Config.pod
+++ b/lib/DJabberd/Config.pod
@@ -54,6 +54,46 @@ intermediate certificates, then finally the root certificate.
 C<SSLCertificateKeyFile> and C<SSLCertificateFile> are required when
 using this option.
 
+=head2 SSLCipherSuite <OpenSSL Cipher String>
+
+Sets ciphersuite constrains for underlying SSL library. By default library
+defaults are used, which changes from version to version. Here you may
+specify either completely paranoidal security ciphers, or otherwise specify
+known broken and disabled by default but required for compatibility ciphers.
+
+Eg. something like
+
+  SSLCipherSuite 'EDH:ECDH:!SSLv2:!SSLv3:!DSS'
+
+should be fairly reasonable
+
+=head2 SSLECDHCurve <EC Curve Name>
+
+To enable ECDHE ciphers one need to specify which elliptic curve should be
+used for this purpose. List of supported curves could be obtained with
+
+  $ openssl ecparam -list_curves
+
+Curves with bitfield over 384 bits as of 2017 are considered a waste of
+resources however are frequently used. The speed drop although is
+considerable (almost twice) so something like
+
+  SSLECDHCurve secp384r1
+
+should provide I<good enough> security.
+
+=head2 SSLDHparamFile C</path/to/dhparam-file.pem>
+
+To use DHE ciphers one need to provide dhparam file of a good quality which
+should be pre-generated (or supplied with OS).
+
+Eg. as example
+
+  SSLDHparamFile /etc/ssl/dhparam-4k.pem
+
+to use system global 4k DH param file  as generating separate 4k for each app
+is a waste of resources.
+
 =head2 OldSSL C<boolean>
 
 Defaults to off; if set, the server will also listen on port 5223, and

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -259,7 +259,7 @@ sub set_to_host {
 
 sub to_host {
     my $self = shift;
-    return $self->{to_host} or
+    return $self->{to_host} ||
         die "To host accessed before it was set";
 }
 
@@ -270,7 +270,7 @@ sub set_version {
 
 sub version {
     my $self = shift;
-    return $self->{version} or
+    return $self->{version} ||
         die "Version accessed before it was set";
 }
 

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -344,7 +344,7 @@ sub send_stanza {
     my $cloned;
     my $getter = sub {
         return $cloned if $cloned;
-        if ($self != $stanza->connection) {
+        if (!$stanza->connection or $self != $stanza->connection) {
             $cloned = $stanza->clone;
             $cloned->set_connection($self);
         } else {
@@ -654,8 +654,14 @@ sub start_stream_back {
         # {=must-send-features-on-1.0}
         if (!$self->{ssl}
             && $self->server->ssl_cert_file
-            && !$self->isa("DJabberd::Connection::ServerIn")) {
-            $features_body .= "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' />";
+            && $self->server->ssl_private_key_file
+        )
+        {
+            # Enforce SSL if configured, but only for C2S conneciton and if we know our VHost
+            $features_body .= "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' "
+                              .((!$self->is_server && $self->vhost && $self->vhost->require_ssl)?
+                                "><required/></starttls>"
+                               :"/>");
         }
         if (my $vh = $self->vhost) {
             $vh->hook_chain_fast("SendFeatures",

--- a/lib/DJabberd/Connection/ClientIn.pm
+++ b/lib/DJabberd/Connection/ClientIn.pm
@@ -196,7 +196,7 @@ sub on_stream_start {
         $opts{features} .= qq{<session xmlns='urn:ietf:params:xml:ns:xmpp-session'/>};
     }
     else {
-        $opts{features} = qq{<auth xmlns='http://jabber.org/features/iq-auth'/>};
+        $opts{features} = qq{<auth xmlns='http://jabber.org/features/iq-auth'/>} unless($self->vhost->require_ssl && !$self->ssl);
     }
     $self->start_stream_back($ss, %opts);
 }

--- a/lib/DJabberd/Connection/ServerIn.pm
+++ b/lib/DJabberd/Connection/ServerIn.pm
@@ -59,6 +59,7 @@ sub on_stanza_received {
                    "{jabber:server}message"  => 'DJabberd::Message',
                    "{jabber:server}presence" => 'DJabberd::Presence',
                    "{http://etherx.jabber.org/streams}features" => 'DJabberd::Stanza::StreamFeatures',
+                   "{urn:ietf:params:xml:ns:xmpp-tls}starttls"  => 'DJabberd::Stanza::StartTLS',
                    );
 
     my $class = $class{$node->element} or

--- a/lib/DJabberd/HookDocs.pm
+++ b/lib/DJabberd/HookDocs.pm
@@ -55,6 +55,16 @@ $hook{'CheckJID'} = {
     },
 };
 
+$hook{'CheckCert'} = {
+    des => "Peer SSL certificate validation",
+    args => [ 'conn' => "Connection", "ok" => 'Pre-verify', "name" => 'CertName', "depth" => 'CurDepth', "err" => 'ErrString', "crt" => 'X509_cert'],
+    callbacks => {
+	pass => [],
+	accept => [],
+	reject => [],
+    },
+};
+
 
 $hook{'pre_stanza_write'} = {
     des => "Called before a stanza is written to a user.  Default action if all declined is to just deliver it.",

--- a/lib/DJabberd/SASL.pm
+++ b/lib/DJabberd/SASL.pm
@@ -30,7 +30,7 @@ sub get_sasl_manager {
 
     no strict 'refs';
     no warnings;
-    unless (defined %{"${class}::"}) {
+    unless (%{"${class}::"}) {
         eval "use $class"; ## no critic
         die $@ if $@;
     }

--- a/lib/DJabberd/SASL/AuthenSASL.pm
+++ b/lib/DJabberd/SASL/AuthenSASL.pm
@@ -20,6 +20,7 @@ sub register {
 
     $vhost->register_hook("SendFeatures", sub {
         my ($vh, $cb, $conn) = @_;
+	$cb->decline if($conn->vhost->require_ssl and ($conn->isa('DJabberd::Connection::ClientIn') && !$conn->ssl));
         if (my $sasl_conn = $conn->sasl) {
             if ($sasl_conn->is_success) {
                 return;


### PR DESCRIPTION
This MR updates TLS implementation to support TLS1.3 and deprecate tls1.1.
Also it introduces additional controls over TLS similar to Apache config (CAs, EC certs, DH params, etc.)
Finally it adds support for <proceed/> nonza to handle S2S encryption both ways.

Closes #41 