### PR TITLE
Caps features rosterver

### DIFF
--- a/lib/DJabberd/Caps.pm
+++ b/lib/DJabberd/Caps.pm
@@ -1,0 +1,329 @@
+package DJabberd::Caps;
+# vim: sts=4 ai:
+use strict;
+use Digest::SHA;
+use Carp;
+use Encode;
+use DJabberd::XMLElement;
+
+use constant { HASH => 'sha-1' };
+
+sub new {
+    my $class = shift;
+    my $self = bless { identity => [], feature => [], form => []}, $class;
+    foreach my$cap(@_) {
+	next unless(ref($cap));
+	$self->add($cap);
+    }
+    return $self;
+}
+
+sub add {
+    my $self = shift;
+    my $cap = shift;
+    if(ref($cap) eq 'DJabberd::XMLElement') {
+	if($cap->element_name eq 'identity') {
+	    $cap = DJabberd::Caps::Identity->new($cap);
+	} elsif($cap->element_name eq 'feature') {
+	    $cap = DJabberd::Caps::Feature->new($cap);
+	} elsif($cap->element eq '{jabber:x:data}x') {
+	    $cap = DJabberd::Caps::Form->new($cap);
+	}
+    }
+    return unless(UNIVERSAL::isa($cap,'DJabberd::Caps::Cap'));
+    push(@{$self->{$cap->type}},$cap);
+}
+
+sub get {
+    my $self = shift;
+    my $type = shift;
+    return @{exists $self->{$type} ? $self->{$type} : []};
+}
+
+sub as_cap {
+    my $self = shift;
+    my $ret = join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{identity}});
+    $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{feature}});
+    $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{form}});
+    return Encode::encode_utf8($ret);
+}
+
+sub as_xml {
+    my $self = shift;
+    return   Encode::decode_utf8(
+	     join('',@{$self->{identity}})
+	    .join('',@{$self->{feature}})
+	    .join('',@{$self->{form}})
+    );
+}
+
+sub digest {
+    my $self = shift;
+    my $hash = shift || HASH;
+    my $ret;
+    $hash =~ s/-//o;
+    eval('$ret = Digest::SHA::'.$hash.'_base64($self->as_cap)');
+    confess($@) if($@);
+    $ret .= '=' while(length($ret) % 4);
+    return $ret;
+}
+
+sub cap_xml {
+    my $self = shift;
+    my $node = shift;
+    my $hash = shift || HASH;
+    return "<c xmlns='http://jabber.org/protocol/caps' hash='$hash' node='$node' ver='".$self->digest($hash)."'/>";
+}
+
+package DJabberd::Caps::Cap;
+
+sub type {
+    croak(__PACKAGE__." must be overriden");
+}
+
+package DJabberd::Caps::Identity;
+use base 'DJabberd::Caps::Cap';
+use overload 'cmp' => \&cmp, '""' => \&as_xml;
+use Carp;
+
+sub type { 'identity' }
+
+sub new {
+    my $class = shift;
+    my ($cat,$type,$name,$lang) = @_;
+    if(!$type) {
+	if(ref($cat) && UNIVERSAL::isa($cat,'DJabberd::XMLElement') && $cat->element_name eq type()) {
+	    my $x = $cat;
+	    $cat  = $x->attr('{}category');
+	    $type = $x->attr('{}type');
+	    $name = $x->attr('{}name');
+	    $lang = $x->attr('{http://www.w3.org/XML/1998/namespace}lang');
+	}
+    } else {
+	$name = Encode::decode_utf8($name);
+    }
+    croak("usage: $class".'->new($category, $type[, $name[, $lang]]) or ->new(DJabberd::XMLElement)') unless($cat && $type);
+    return bless { category => $cat, type => $type, name => $name, lang => $lang}, $class;
+}
+
+sub cmp {
+    my $self = shift;
+    my $dude = shift;
+    return ($self->{category} cmp $dude->{category} || $self->{type} cmp $dude->{type} || ($self->{lang} && $dude->{lang} && $self->{lang} cmp $dude->{lang}));
+}
+
+sub as_xml {
+    my $self = shift;
+    return '<identity category="'.$self->{category}.'" type="'.$self->{type}.'"'
+	    .($self->{name} ? ' name="'.Encode::encode_utf8($self->{name}).'"'	: '')
+	    .($self->{lang} ? ' xml:lang="'.$self->{lang}.'"'	: '')
+	    .'/>';
+}
+
+sub as_element {
+    my $self = shift;
+    return DJabberd::XMLElement->new('','identity',{
+		category => $self->{category},
+		type => $self->{type},
+		($self->{name} ? (name=>$self->{name}) : ()),
+		($self->{lang} ? ('xml:lang' => $self->{lang}) : ())
+	}, 
+	[]
+    );
+}
+
+sub as_cap {
+    my $self = shift;
+    return $self->{category}.'/'.$self->{type}.'/'.($self->{lang} || '').'/'.($self->{name} || '').'<';
+}
+
+sub bare {
+    my $self = shift;
+    my $ret = [ $self->{category}, $self->{type} ];
+    push(@{$ret}, $self->{name}) if($self->{name});
+    push(@{$ret}, $self->{lang}) if($self->{lang});
+    return $ret;
+}
+
+package DJabberd::Caps::Feature;
+use base 'DJabberd::Caps::Cap';
+use overload 'cmp' => \&cmp, '""' => \&as_xml;
+use Carp;
+
+sub type { 'feature' }
+
+sub new {
+    my $class = shift;
+    my $var;
+    if(ref($_[0]) && UNIVERSAL::isa($_[0],'DJabberd::XMLElement') && $_[0]->element_name eq type()) {
+	$var = $_[0]->attr('{}var');
+    } else {
+	$var = shift;
+    }
+    croak("Feature may not be empty") unless($var);
+    return bless {var => $var}, $class; 
+}
+
+sub cmp {
+    my $self = shift;
+    my $dude = shift;
+    return ($self->{var} cmp $dude->{var});
+}
+
+sub as_xml {
+    my $self = shift;
+    return '<feature var="'.$self->{var}.'"/>';
+}
+
+sub as_element {
+    my $self = shift;
+    return DJabberd::XMLElement->new('','feature',{var => $self->{var}},[]);
+}
+
+sub as_cap {
+    my $self = shift;
+    return $self->{var}.'<';
+}
+
+sub bare {
+    my $self = shift;
+    return $self->{var};
+}
+
+package DJabberd::Caps::Form;
+use base 'DJabberd::Caps::Cap';
+use overload 'cmp' => \&cmp, '""' => \&as_xml;
+use Carp;
+
+sub type { 'form' }
+
+sub new {
+    my $class = shift;
+    my $self;
+    # Try to create from XMLElement tree
+    if(@_ && $_[0] && ref($_[0]) && UNIVERSAL::isa($_[0],'DJabberd::XMLElement') && $_[0]->element eq '{jabber:x:data}x' && $_[0]->children) {
+	$self = from_element($_[0]);
+    } else {
+	# Or from raw struct
+	my $type = shift;
+	my $fields = shift;
+	my %args = @_;
+	if($type && ref($fields) eq 'ARRAY' && @{$fields}) {
+	    $self = { type => $type, fields => {}, order => []};
+	    foreach my$f(@{$fields}) {
+		if(ref($f) eq 'HASH' && $f->{var} && ref($f->{value}) eq 'ARRAY') {
+		    push(@{$self->{order}},$f->{var});
+		    $self->{fields}->{$f->{var}} = $f;
+		}
+	    }
+	    $self->{title} = $args{title} if($args{title});
+	    $self->{instructions} = $args{instructions} if(ref($args{instructions}) eq 'ARRAY');
+	}
+    }
+    croak("Form may not be empty") unless(ref($self) eq 'HASH' && @{$self->{order}});
+    return bless $self, $class; 
+}
+sub from_element {
+    my $x = shift;
+    my @inst;
+    my $title;
+    my %field;
+    my @order;
+    foreach my$el($x->children_elements) {
+	if($el->element_name eq 'title') {
+	    $title = $el->innards_as_xml;
+	} elsif($el->element_name eq 'instructions') {
+	    push(@inst,$el->innards_as_xml);
+	} elsif($el->element_name eq 'field') {
+	    my $field = {
+		var => $el->attr('{}var'),
+		type => $el->attr('{}type'),
+		label => $el->attr('{}label'),
+		value => [],
+		option => []
+	    };
+	    foreach my$c($el->children_elements) {
+		if($c->element_name eq 'desc') {
+		    $field->{desc} = $c->innards_as_xml;
+		} elsif($c->element_name eq 'required') {
+		    $field->{required} = 1;
+		} elsif($c->element_name eq 'value') {
+		    push(@{$field->{value}},$c->innards_as_xml);
+		} elsif($c->element_name eq 'option') {
+		    my $option = { value => $c->first_element->innards_as_xml };
+		    $option->{label} = $c->attr('{}label') if($c->attr('{}label'));
+		    push(@{$field->{option}},$option);
+		}
+	    }
+	    push(@order,$field->{var});
+	    $field{$field->{var}} = $field;
+	}
+    }
+    return {type => $x->attr('{}type'), title => $title, instructions => \@inst, fields => \%field, order => \@order};
+}
+sub cmp {
+    my $self = shift;
+    my $dude = shift;
+    return (($self->{fields}->{FORM_TYPE}->{value}->[0] || '~'x9) cmp ($dude->{fields}->{FORM_TYPE}->{value}->[0] || '~'x9));
+}
+sub as_xml {
+    my $self = shift;
+    my $xml = '<x xmlns="jabber:x:data" type="'.$self->{type}.'">';
+    $xml .= ('<title>'.$self->{title}.'</title>') if($self->{title});
+    foreach my$i(@{$self->{instructions}}) {
+	$xml .= "<instructions>$i</instructions>";
+    }
+    foreach my$v(@{$self->{order}}) {
+	$xml .= '<field var="'.$self->{fields}->{$v}->{var}.'"'
+		.($self->{fields}->{$v}->{type} ? ' type="'.$self->{fields}->{$v}->{type}.'"':'')
+		.($self->{fields}->{$v}->{label} ? ' label="'.$self->{fields}->{$v}->{label}.'"':'')
+		.'>';
+	$xml .= ('<desc>'.$self->{fields}->{$v}->{desc}.'</desc>') if($self->{fields}->{$v}->{desc});
+	$xml .= ('<required/>') if($self->{fields}->{$v}->{required});
+	foreach my$k(@{$self->{fields}->{$v}->{value}}) {
+	    $xml .= "<value>$k</value>";
+	}
+	foreach my$k(@{$self->{fields}->{$v}->{option}}) {
+	    $xml .= '<option'.($k->{label} ? ' label="'.$k->{label}.'"':'').'><value>'.$k->{value}.'</value></option>';
+	}
+	$xml .= '</field>';
+    }
+    return "$xml</x>";
+}
+sub as_cap {
+    my $self = shift;
+    return '' unless(exists $self->{fields}->{FORM_TYPE} && ref($self->{fields}->{FORM_TYPE}));
+    my $cap = $self->{fields}->{FORM_TYPE}->{value}->[0].'<';
+    foreach my$f(sort{$a cmp $b}keys(%{$self->{fields}})) {
+	next if($f eq 'FORM_TYPE');
+	$cap .= ("$f<".join('<',@{$self->{fields}->{$f}->{value}}).'<');
+    }
+    return $cap;
+}
+sub as_element {
+    my $self = shift;
+    my @innards;
+    push(@innards,DJabberd::XMLElement->new('','title',{},[$self->{title}])) if($self->{title});
+    foreach my$i(@{$self->{instructions}}) {
+	push(@innards,DJabberd::XMLElement->new('','instructions',{},[$i]));
+    }
+    foreach my$v(@{$self->{order}}) {
+	my $attr = { var => $v };
+	$attr->{type} = $self->{fields}->{$v}->{type} if($self->{fields}->{$v}->{type});
+	$attr->{label} = $self->{fields}->{$v}->{label} if($self->{fields}->{$v}->{label});
+	my $kids = [];
+	push(@{$kids},DJabberd::XMLElement->new('','desc',{},[$self->{fields}->{$v}->{desc}])) if($self->{fields}->{$v}->{desc});
+	push(@{$kids},DJabberd::XMLElement->new('','required',{},[])) if($self->{fields}->{$v}->{required});
+	foreach my$k(@{$self->{fields}->{$v}->{value}}) {
+	    push(@{$kids},DJabberd::XMLElement->new('','value',{},[$k]));
+	}
+	foreach my$k(@{$self->{fields}->{$v}->{option}}) {
+	    my $oa = {};
+	    $oa->{label} = $k->{label} if($k->{label});
+	    push(@{$kids},DJabberd::XMLElement->new('','option',$oa,[DJabberd::XMLElement->new('','value',{},[$k->{value}])]));
+	}
+	push(@innards,DJabberd::XMLElement->new('','field',$attr,$kids));
+    }
+    return DJabberd::XMLElement->new('','x',{xmlns=>'jabber:x:data'},\@innards);
+}
+1;

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -663,15 +663,19 @@ sub start_stream_back {
                                 "><required/></starttls>"
                                :"/>");
         }
-	my $caps = "";
+        my $caps = "";
         if (my $vh = $self->vhost) {
-	    $caps = $vh->caps->cap_xml('http://danga.com/djabberd/');
+            $caps = $vh->caps->cap_xml('http://danga.com/djabberd/');
             $vh->hook_chain_fast("SendFeatures",
                                   [ $self ],
                                   {
                                       stanza => sub {
-                                        my ($self, $xml_string) = @_;
+                                        my ($self, $xml_string, $final) = @_;
                                         $features_body .= $xml_string;
+                                        return if($final);
+                                        # try to collect more features from plugins
+                                        $self->reset;
+                                        $self->decline;
                                       },
                                   }
                                   );

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -663,7 +663,9 @@ sub start_stream_back {
                                 "><required/></starttls>"
                                :"/>");
         }
+	my $caps = "";
         if (my $vh = $self->vhost) {
+	    $caps = $vh->caps->cap_xml('http://danga.com/djabberd/');
             $vh->hook_chain_fast("SendFeatures",
                                   [ $self ],
                                   {
@@ -674,7 +676,7 @@ sub start_stream_back {
                                   }
                                   );
         }
-        $features = qq{<stream:features>$features_body</stream:features>};
+        $features = qq{<stream:features>$caps$features_body</stream:features>};
     }
 
     # The receiving entity MUST set the value of the 'version'

--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -137,13 +137,7 @@ sub process_iq_disco_info_query {
     # capabilities we have
     my $xml;
     $xml  = qq{<query xmlns='http://jabber.org/protocol/disco#info'>};
-    $xml .= qq{<identity category='server' type='im' name='djabberd'/>};
-
-    foreach my $cap ('http://jabber.org/protocol/disco#info',
-                     $conn->vhost->features)
-    {
-        $xml .= "<feature var='$cap'/>";
-    }
+    $xml .= $conn->vhost->caps->as_xml;
     $xml .= qq{</query>};
 
     $iq->send_reply('result', $xml);

--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -162,13 +162,31 @@ sub process_iq_getroster {
 
     my $send_roster = sub {
         my $roster = shift;
+        my $ver = $iq->query->attr('{}ver');
+	my @items = $roster->items;
+        $logger->debug("Got IQ ver $ver and roster with ".scalar(@items)." items from ".(ref($items[0]) ? $items[0]->ver:'<undef>')." to ".(ref($items[-1]) ? $items[-1]->ver : '<undef>'));
+        # If versioning is consistent - use versioned push. Otherwise fall back to full roster push
+        if($ver && scalar(@items)>5 && ref($items[0]) && $items[0]->ver <= $ver && ref($items[-1]) && $ver <= $items[-1]->ver) {
+            $logger->info("Pushing roster after $ver to conn $conn->{id}");
+            # Make diff push instead of full load
+            my $rsp = __PACKAGE__->new('','iq',{'{}type'=>'result'});
+            $rsp->set_to($iq->connection->bound_jid);
+            $rsp->set_from($iq->connection->bound_jid->as_bare_string);
+            $rsp->set_attr('{}id',$iq->attr('{}id')) if($iq->attr('{}id'));
+            my $xml = $rsp->as_xml;
+	    $iq->connection->xmllog->info($xml);
+            $iq->connection->write(\$xml);
+            # Empty response indicates roster will be delivered as series of pushes
+            foreach my$ri(@items) {
+                $iq->connection->vhost->roster_push($iq->connection->bound_jid,$ri,1) if($ri->ver > $ver);
+            }
+            return;
+        }
         $logger->info("Sending roster to conn $conn->{id}");
         $iq->send_result_raw($roster->as_xml);
 
         # JIDs who want to subscribe to us, since we were offline
-        foreach my $jid (map  { $_->jid }
-                         grep { $_->subscription->pending_in }
-                         $roster->items) {
+        foreach my $jid (map  { $_->jid } grep { $_->subscription->pending_in } @items) {
             my $subpkt = DJabberd::Presence->make_subscribe(to   => $conn->bound_jid,
                                                             from => $jid);
             # already in roster as pendin, we've already processed it,
@@ -264,7 +282,7 @@ sub process_iq_setroster {
                                          my ($self, $ritem_final) = @_;
 
                                          # the RosterRemoveItem isn't required to return the final item
-                                         $ritem_final = $ritem if $removing;
+                                         $ritem_final = $ritem if !$ritem_final and $removing;
 
                                          $iq->send_result;
                                          $conn->vhost->roster_push($conn->bound_jid, $ritem_final);

--- a/lib/DJabberd/Roster.pm
+++ b/lib/DJabberd/Roster.pm
@@ -34,22 +34,28 @@ sub items {
 
 sub from_items {
     my $self = shift;
-    return grep { $_->subscription->sub_from } @{ $self->{items} };
+    return grep { !$_->remove && $_->subscription->sub_from } @{ $self->{items} };
 }
 
 sub to_items {
     my $self = shift;
-    return grep { $_->subscription->sub_to } @{ $self->{items} };
+    return grep { !$_->remove && $_->subscription->sub_to } @{ $self->{items} };
 }
 
 sub as_xml {
     my $self = shift;
-    my $xml = "<query xmlns='jabber:iq:roster'>";
-    foreach my $it (@{ $self->{items} }) {
-        next if $it->subscription->is_none_pending_in;
-        $xml .= $it->as_xml;
+    my $ver = (@{$self->{items}} && $self->{items}->[-1]->ver)? " ver='".$self->{items}->[-1]->ver."'":'';
+    my $xml = "<query xmlns='jabber:iq:roster'$ver";
+    if(@{$self->{items}}) {
+        $xml .= ">";
+        foreach my $it (@{ $self->{items} }) {
+            next if $it->subscription->is_none_pending_in || $it->remove;
+            $xml .= $it->as_xml;
+        }
+        $xml .= "</query>";
+    } else {
+        $xml .= "/>";
     }
-    $xml .= "</query>";
     return $xml;
 }
 

--- a/lib/DJabberd/SASL.pm
+++ b/lib/DJabberd/SASL.pm
@@ -72,9 +72,8 @@ sub register {
     $vhost->register_hook("HandleStanza", sub {
         my (undef, $cb, $node) = @_;
         my $class = $sasl_elements{$node->element};
-        return unless $class;
+        return $cb->decline unless $class;
         $cb->handle($class);
-        return;
     });
 }
 

--- a/lib/DJabberd/SASL/AuthenSASL.pm
+++ b/lib/DJabberd/SASL/AuthenSASL.pm
@@ -20,11 +20,9 @@ sub register {
 
     $vhost->register_hook("SendFeatures", sub {
         my ($vh, $cb, $conn) = @_;
-	$cb->decline if($conn->vhost->require_ssl and ($conn->isa('DJabberd::Connection::ClientIn') && !$conn->ssl));
+        return $cb->decline if($conn->vhost->require_ssl and ($conn->isa('DJabberd::Connection::ClientIn') && !$conn->ssl));
         if (my $sasl_conn = $conn->sasl) {
-            if ($sasl_conn->is_success) {
-                return;
-            }
+            return $cb->decline if ($sasl_conn->is_success);
         }
         my @mech = $plugin->mechanisms_list;
         my $xml_mechanisms =

--- a/lib/DJabberd/XMLElement.pm
+++ b/lib/DJabberd/XMLElement.pm
@@ -160,6 +160,8 @@ sub as_xml {
 
     $nsmap->{xmlns} = 'http://www.w3.org/2000/xmlns';
     $nsmap->{'http://www.w3.org/2000/xmlns'} = 'xmlns';
+    $nsmap->{xml} = 'http://www.w3.org/XML/1998/namespace';
+    $nsmap->{'http://www.w3.org/XML/1998/namespace'} = 'xml';
 
     # let's feed the nsmap...
     foreach my $k (keys %$attr) {

--- a/t/caps.t
+++ b/t/caps.t
@@ -1,0 +1,154 @@
+use strict;
+use warnings;
+use DJabberd::Caps;
+use Test::More tests => 8;
+
+# We use _complex_ show case of the XEP-0115 [5.3] to test validness
+# See: http://xmpp.org/extensions/xep-0115.html##ver-gen-complex
+#
+#  <query xmlns='http://jabber.org/protocol/disco#info'
+#         node='http://psi-im.org#q07IKJEyjvHSyhy//CH0CxmKi8w='>
+#    <identity xml:lang='en' category='client' name='Psi 0.11' type='pc'/>
+#    <identity xml:lang='el' category='client' name='Ψ 0.11' type='pc'/>
+#    <feature var='http://jabber.org/protocol/caps'/>
+#    <feature var='http://jabber.org/protocol/disco#info'/>
+#    <feature var='http://jabber.org/protocol/disco#items'/>
+#    <feature var='http://jabber.org/protocol/muc'/>
+#    <x xmlns='jabber:x:data' type='result'>
+#      <field var='FORM_TYPE' type='hidden'>
+#        <value>urn:xmpp:dataforms:softwareinfo</value>
+#      </field>
+#      <field var='ip_version'>
+#        <value>ipv4</value>
+#        <value>ipv6</value>
+#      </field>
+#      <field var='os'>
+#        <value>Mac</value>
+#      </field>
+#      <field var='os_version'>
+#        <value>10.5.1</value>
+#      </field>
+#      <field var='software'>
+#        <value>Psi</value>
+#      </field>
+#      <field var='software_version'>
+#        <value>0.11</value>
+#      </field>
+#    </x>
+#  </query>
+#
+my $caps = 'client/pc/el/Ψ 0.11<client/pc/en/Psi 0.11<http://jabber.org/protocol/caps<http://jabber.org/protocol/disco#info<http://jabber.org/protocol/disco#items<http://jabber.org/protocol/muc<urn:xmpp:dataforms:softwareinfo<ip_version<ipv4<ipv6<os<Mac<os_version<10.5.1<software<Psi<software_version<0.11<';
+my $hash = 'q07IKJEyjvHSyhy//CH0CxmKi8w=';
+my $entc = "<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='http://psi-im.org' ver='q07IKJEyjvHSyhy//CH0CxmKi8w='/>";
+my $c = DJabberd::Caps->new(
+	DJabberd::Caps::Identity->new('client','pc', 'Psi 0.11', 'en'),
+	DJabberd::Caps::Identity->new('client','pc', 'Ψ 0.11', 'el'),
+	DJabberd::Caps::Feature->new('http://jabber.org/protocol/caps'),
+	DJabberd::Caps::Feature->new('http://jabber.org/protocol/disco#info'),
+	DJabberd::Caps::Feature->new('http://jabber.org/protocol/disco#items'),
+	DJabberd::Caps::Feature->new('http://jabber.org/protocol/muc'),
+	DJabberd::Caps::Form->new('result', [
+		{ var => 'FORM_TYPE', type => 'hidden', value => [ 'urn:xmpp:dataforms:softwareinfo' ] },
+		{ var => 'ip_version', value => [ 'ipv4', 'ipv6' ] },
+		{ var => 'os', value => [ 'Mac' ] },
+		{ var => 'os_version', value => [ '10.5.1' ] },
+		{ var => 'software', value => [ 'Psi' ] },
+		{ var => 'software_version', value => [ '0.11' ] }
+	])
+);
+print "".('-'x9)."\nXML Out:\n";
+print $c->as_xml;
+print "\n".('-'x9)."\nCAP Out:\n";
+print $c->as_cap;
+print "\n".('-'x9)."\nDigest:\n";
+print $c->digest;
+print "\n".('-'x9)."\nEntity:\n";
+print $c->cap_xml('http://psi-im.org');
+print "\n".('-'x9)."\nChecks:\n";
+like($c->as_xml,qr(xml:lang=["']el["']), "XML Lang attribute found");
+like($c->as_xml,qr(<field var=["']FORM_TYPE["'] type=["']hidden["']>),"Form fields attributes");
+ok($caps eq $c->as_cap, "Cap string matches");
+ok($hash eq $c->digest, "Cap digest matches");
+ok($entc eq $c->cap_xml('http://psi-im.org'), "Cap entity matches");
+
+#######################
+#  XML Parsing check  #
+#######################
+use DJabberd::SAXHandler;
+use DJabberd::XMLParser;
+use DJabberd::Stats;
+my $q = {};
+my $cb = CB->new(sub {
+	$q = shift;
+});
+
+my $h=DJabberd::SAXHandler->new;
+my $p=DJabberd::XMLParser->new(Handler => $h);
+$p->parse_chunk("<stream:stream xmlns:stream='jabber:client'>");
+$h->set_connection($cb);
+$p->parse_chunk(qq{
+  <query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://psi-im.org#q07IKJEyjvHSyhy//CH0CxmKi8w='>
+    <identity xml:lang='en' category='client' name='Psi 0.11' type='pc'/>
+    <identity xml:lang='el' category='client' name='Ψ 0.11' type='pc'/>
+    <feature var='http://jabber.org/protocol/caps'/>
+    <feature var='http://jabber.org/protocol/disco#info'/>
+    <feature var='http://jabber.org/protocol/disco#items'/>
+    <feature var='http://jabber.org/protocol/muc'/>
+    <x xmlns='jabber:x:data' type='result'>
+      <field var='FORM_TYPE' type='hidden'>
+        <value>urn:xmpp:dataforms:softwareinfo</value>
+      </field>
+      <field var='ip_version'>
+        <value>ipv4</value>
+        <value>ipv6</value>
+      </field>
+      <field var='os'>
+        <value>Mac</value>
+      </field>
+      <field var='os_version'>
+        <value>10.5.1</value>
+      </field>
+      <field var='software'>
+        <value>Psi</value>
+      </field>
+      <field var='software_version'>
+        <value>0.11</value>
+      </field>
+    </x>
+  </query>
+});
+print "".('-'x9)."\nXML Original:\n";
+print $q->as_xml;
+print "\n".('-'x9)."\nXML Decoded:\n";
+my $x = DJabberd::Caps->new($q->children_elements);
+my $xml = $x->as_xml;
+print $xml;
+print "\n".('-'x9)."\nCap string:\n";
+print $x->as_cap;
+print "\n".('-'x9)."\nDigest:\n";
+print $x->digest;
+print "\n".('-'x9)."\nChecks:\n";
+ok($x->as_cap eq $caps, "XML Transcoding check - caps export matches original caps");
+ok($x->digest eq $hash, "XML Transcoding check - decoded digest matches original one");
+
+##
+# Re-parse parsed-and-exported XML again and compare hashes
+my $qo = $q;
+$p->parse_chunk(qq{<q xmlns='disco:info'>$xml</q>});
+my $xn = DJabberd::Caps->new($q->children_elements);
+print "\n".('-'x9)."\nCap string:\n";
+print $xn->as_cap;
+print "\n".('-'x9)."\nChecks:\n";
+ok($qo != $q && $xn->digest eq $hash, "XML Transcoding check - recoded digest matches original one");
+
+package CB;
+
+sub new {
+  my $class = shift;
+  return bless { in_stream => 1, cb => $_[0] }, $class;
+}
+sub on_stanza_received {
+    my $self = shift;
+    $self->{cb}->(@_);
+}


### PR DESCRIPTION
and Forms (as needed by caps). so far inside Caps.pm, will be moved off to standalone file in further commits.

As described in commit messages it introduces new class for Feature, Identity, Form, implements Caps class which can serialize Features/Identities/Forms and calculate digest for XEP-0115.
Feature hook is reworked to be repeatable (auto-reset) to collect features/identities/caps from whoever wants to join the party (eg rosterver).
Roster management is updated to support rosterver feature however it needs rosterver-aware storage plugin to support that.

Closes #8 