### PR TITLE
Plugin ordering, IQ handling, foundation for SM and BiDi

### DIFF
--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -292,6 +292,23 @@ sub set_config_casesensitive {
     $DJabberd::JID::CASE_SENSITIVE = as_bool($val);
 }
 
+sub set_config_s2sservertransport {
+    my ($self, $val) = @_;
+    eval("use $val");
+    croak("Can't use $val as s2s transport: $@") if($@);
+    $self->{s2ss_class} = $val;
+}
+
+sub set_config_s2sclienttransport {
+    my ($self, $val) = @_;
+    eval("use $val");
+    croak("Can't use $val as s2s transport: $@") if($@);
+    $self->{s2sc_class} = $val;
+}
+
+sub s2s_server_class { return ( $_[0]->{s2ss_class} || 'DJabberd::Connection::ServerIn') }
+sub s2s_client_class { return ( $_[0]->{s2sc_class} || 'DJabberd::Connection::ServerOut') }
+
 sub add_vhost {
     my ($self, $vhost) = @_;
     my $sname = lc $vhost->name;
@@ -527,7 +544,7 @@ sub start_c2s_server {
 sub start_s2s_server {
     my $self = shift;
     $self->_start_servers($self->{s2s_port},
-                         "DJabberd::Connection::ServerIn");
+                          $self->s2s_server_class);
 }
 
 sub start_cluster_server {

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -139,6 +139,14 @@ sub new_iq_id {
     return "iq$self->{iqctr}";
 }
 
+sub own_iq_id {
+    my DJabberd::Connection $self = shift;
+    if($_[0] =~ /iq(\d+)/o) {
+        return ($1 <= $self->{iqctr});
+    }
+    return 0;
+}
+
 sub log_outgoing_data {
     my ($self, $text) = @_;
     my $id = $self->{id} ||= 'no_id';

--- a/lib/DJabberd/Connection/ServerIn.pm
+++ b/lib/DJabberd/Connection/ServerIn.pm
@@ -85,17 +85,20 @@ sub filter_incoming_server_builtin {
     my ($self, $stanza) = @_;
 
     unless ($stanza->acceptable_from_server($self)) {
+	my $err = "improper-addressing";
+	my $info;
         if (not $stanza->from_jid) {
-            $self->log->error("Invalid 'from': @{[$stanza->from]}");
+            $info="Invalid 'from': @{[$stanza->from]}";
         } elsif (not $stanza->to_jid) {
-            $self->log->error("Invalid 'to': @{[$stanza->to]}");
+            $info="Invalid 'to': @{[$stanza->to]}";
         } else {
             my $domain = $stanza->from_jid->domain;
             my @known = sort keys %{$self->{verified_remote_domain}};
-            $self->log->error("Stanza of type '@{[ref $stanza]}' from $domain not acceptable; accept @known");
+            $info="Stanza of type '@{[ref $stanza]}' from $domain not acceptable; accept @known";
         }
+        $self->log->error($info);
         # FIXME: who knows.  send something else.
-        $self->stream_error;
+        $self->stream_error($err,$info);
         return 0;
     }
 

--- a/lib/DJabberd/Connection/ServerOut.pm
+++ b/lib/DJabberd/Connection/ServerOut.pm
@@ -24,7 +24,7 @@ sub new {
     # We need either an IP or and enpoint (which includes an ip and a port)
     croak "No 'ip' or 'endpoint'\n" unless ($ip || $endpt);
     # If we got no endpoint well construct one using the supplied IP and the default port
-    $endpt ||= DJabberd::IPEndpoint->new($ip, 5269);
+    $endpt ||= DJabberd::IPEndPoint->new($ip, 5269);
     $ip = $endpt->addr;
 
     my $sock;

--- a/lib/DJabberd/Delivery.pm
+++ b/lib/DJabberd/Delivery.pm
@@ -11,10 +11,15 @@ sub finalize {
     $self->SUPER::finalize();
 }
 
+# if you want to hide specific object class behind parent implementation
+sub package {
+    return ''
+}
+
 sub register {
     my ($self, $vhost) = @_;
     $self->set_vhost($vhost);
-    $vhost->register_hook("deliver", sub { $self->deliver(@_) });
+    $vhost->register_hook("deliver", sub { $self->deliver(@_) }, $self->package || ref($self));
 }
 
 sub vhost {

--- a/lib/DJabberd/Delivery/Local.pm
+++ b/lib/DJabberd/Delivery/Local.pm
@@ -11,7 +11,12 @@ sub deliver {
 
     my @dconns;
     my $find_bares = sub {
-        @dconns = grep { $_->is_available || $stanza->deliver_when_unavailable } $vhost->find_conns_of_bare($to)
+        @dconns = grep {
+		# Thou shalt not broadcast IQ!
+		($stanza->element_name ne 'iq' || $to->as_string eq $_->bound_jid->as_string)
+		# deliverability check
+	        && ($_->is_available || $stanza->deliver_when_unavailable)
+	    } $vhost->find_conns_of_bare($to)
     };
 
     if ($to->is_bare) {

--- a/lib/DJabberd/HookDocs.pm
+++ b/lib/DJabberd/HookDocs.pm
@@ -71,6 +71,19 @@ $hook{'pre_stanza_write'} = {
 };
 
 $hook{'c2s-iq'} = {};
+$hook{'s2s-iq'} = {};
+
+$hook{'DiscoBare'} = {
+    des => "Called when disco IQ against bare jid is requested",
+    args => ['IQ', 'info|items', 'bare', 'from', 'ritem'],
+    callbacks => {
+        addFeatures => [ '(Namespace,)' ],
+        setFeatures => [ '(Namespace,)' ],
+	addItems => [ '([ jid, node, name ],)' ],
+	setItems => [ '([ jid, node, name ],)' ],
+    },
+};
+
 $hook{'deliver'} = {
     args => ['Stanza'],
 };

--- a/lib/DJabberd/IQ.pm
+++ b/lib/DJabberd/IQ.pm
@@ -39,6 +39,7 @@ my $iq_handler = {
     'get-{jabber:iq:register}query' => \&process_iq_getregister,
     'set-{jabber:iq:register}query' => \&process_iq_setregister,
     'set-{djabberd:test}query' => \&process_iq_set_djabberd_test,
+    'result-(BOGUS)' => \&process_iq_result_empty,
 };
 
 # DO NOT OVERRIDE THIS
@@ -750,6 +751,15 @@ sub process_iq_set_djabberd_test {
     }
 
     $iq->send_result_raw("<unknown-command/>");
+}
+
+sub process_iq_result_empty {
+    my ($conn, $iq) = @_;
+    # Empty result back to server does not require any action. Just to suppress
+    # error response, and signal if anything doesn't look right
+    unless($conn->own_iq_id($iq->id)) {
+        $logger->error("Got result for unknown id: ".$iq->as_xml);
+    }
 }
 
 sub id {

--- a/lib/DJabberd/Plugin.pm
+++ b/lib/DJabberd/Plugin.pm
@@ -24,6 +24,12 @@ sub finalize {
 }
 
 # list of classnames you want to run before/after (in your phase only)
+# eg. could be implemented as simple return qw{DJabberd::Delivery::S2S}
+# to have static order for all phases or more complex like
+# return {
+#         deliver => 'DJabberd::Delivery::Local',
+#         AlterPresenceUnavailable => 'ALL'
+#     }->{$_[1]};
 sub run_after {
     return ()
 }

--- a/lib/DJabberd/Presence.pm
+++ b/lib/DJabberd/Presence.pm
@@ -453,7 +453,7 @@ sub _process_outbound_available {
                                args  => [ $conn, $self ],
                                methods => {
                                    done => sub {
-                                       return if $conn->{closed};
+                                       return if $conn->{closed} > 0;
                                        $self->_process_outbound_available($conn, 1);
                                    },
                                },
@@ -489,7 +489,7 @@ sub _process_outbound_unavailable {
                                args  => [ $conn, $self ],
                                methods => {
                                    done => sub {
-                                       return if $conn->{closed};
+                                       return if $conn->{closed} > 0;
                                        $self->_process_outbound_unavailable($conn, 1);
                                    },
                                },

--- a/lib/DJabberd/Queue.pm
+++ b/lib/DJabberd/Queue.pm
@@ -33,6 +33,7 @@ sub new {
 
     $self->{vhost}      = delete $opts{vhost}  or die "vhost required";
     Carp::croak("Not a vhost: $self->{vhost}") unless $self->vhost->isa("DJabberd::VHost");
+    Scalar::Util::weaken($self->{vhost});
 
     if (my $endpoints = delete $opts{endpoints}) {
         Carp::croak("endpoints must be an arrayref") unless (ref $endpoints eq 'ARRAY');
@@ -133,7 +134,7 @@ sub on_connection_failed {
 sub on_connection_error {
    my ($self, $conn) = @_;
    $logger->debug("connection error for queue");
-   return unless $conn == $self->{connection};
+   return unless(defined $self->{connection} && $conn == $self->{connection});
    $logger->debug("  .. match");
    my $pre_state = $self->{state};
 

--- a/lib/DJabberd/Queue/ServerOut.pm
+++ b/lib/DJabberd/Queue/ServerOut.pm
@@ -76,7 +76,7 @@ sub new_connection {
     my $self = shift;
     my %opts = @_;
 
-    return DJabberd::Connection::ServerOut->new(%opts);
+    return $self->vhost->server->s2s_client_class->new(%opts);
 }
 
 1;

--- a/lib/DJabberd/SAXHandler.pm
+++ b/lib/DJabberd/SAXHandler.pm
@@ -128,7 +128,11 @@ sub end_element {
 
     if ($data->{NamespaceURI} eq "http://etherx.jabber.org/streams" &&
         $data->{LocalName} eq "stream") {
-        $self->{ds_conn}->end_stream if $self->{ds_conn};
+	if($self->{ds_conn}) {
+            $self->{ds_conn}->log->debug($self->{ds_conn}->{id}.' < '.
+		    '</'.$data->{Name}." xmlns".($data->{Prefix}?':'.$data->{Prefix}:'')."='".$data->{NamespaceURI}."'>");
+            $self->{ds_conn}->end_stream;
+        }
         return;
     }
 

--- a/lib/DJabberd/SAXHandler.pm
+++ b/lib/DJabberd/SAXHandler.pm
@@ -89,6 +89,12 @@ sub start_element {
     $self->{on_end_capture} = sub {
         my ($doc, $events) = @_;
         my $nodes = _nodes_from_events($events);
+        if ($nodes->[0]->element eq "{http://etherx.jabber.org/streams}error") {
+	    $conn->log->warn("Stream error: ".$nodes->[0]->innards_as_xml);
+            $conn->end_stream;
+            return;
+        }
+
         # {=xml-stanza}
         my $t1 = Time::HiRes::time();
         $conn->on_stanza_received($nodes->[0]) if $conn;

--- a/lib/DJabberd/Stanza.pm
+++ b/lib/DJabberd/Stanza.pm
@@ -166,7 +166,7 @@ sub make_error_response {
     $to ? $response->set_from($to) : delete($response->attrs->{"{}from"});
 
     my $error_elem = new DJabberd::XMLElement(
-        "jabber:server",
+        $self->namespace,
         "error",
         {
             "{}code" => $code,

--- a/lib/DJabberd/VHost.pm
+++ b/lib/DJabberd/VHost.pm
@@ -25,6 +25,9 @@ sub new {
         'jid2sock'      => {},  # bob@207.7.148.210/rez -> DJabberd::Connection
         'bare2fulls'    => {},  # barejids -> { fulljid -> 1 }
 
+        # external connections
+        'dest2queue'    => {},  # example.com => DJabberd::Queue
+
         'quirksmode'    => 1,
 
         'server_secret' => undef,  # server secret we use for dialback HMAC keys.  trumped
@@ -397,6 +400,21 @@ sub register_hook {
     	$logger->debug('New order for phase '.$phase.' is '.join(', ',map{$_->{pkg}}@hooks));
     }
     $self->{hooks}{$phase} = \@hooks;
+}
+
+# lookup an external domain queue
+sub find_queue {
+    my ($self, $domain) = @_;
+    return $self->find_queue($domain->domain) if(ref($domain));
+    return $self->{dest2queue}->{$domain};
+}
+
+sub add_queue {
+    $_[0]->{dest2queue}->{$_[1]} = $_[2];
+}
+
+sub del_queue {
+    return delete $_[0]->{dest2queue}->{$_[1]};
 }
 
 # lookup a local user by fulljid

--- a/lib/DJabberd/VHost.pm
+++ b/lib/DJabberd/VHost.pm
@@ -367,7 +367,7 @@ sub find_jid {
     my ($self, $jid) = @_;
     return $self->find_jid($jid->as_string) if ref $jid;
     my $sock = $self->{jid2sock}{$jid} or return undef;
-    return undef if $sock->{closed};
+    return undef if $sock->{closed} > 0;
     return $sock;
 }
 


### PR DESCRIPTION
This PR creates a foundation for XEP-0198 and XEP-0288 as well as it finally implements flexible plugin ordering. In addition it makes several fixes in IQ handling - IQ result, IQ error, IQ c2s delivery.
For SM it introduces possibility for plugins to inject/intercept write and close calls in ::Connection class.
For BiDi it moves S2S queue to VHost (from delivery) and adds ability to provide custom S2S/C2S class to VHost.
Ordering now can be done per-hook, with before-all/after-all options to execute latest (or firstest) or with Class name to set precedence/dependency.