### PR TITLE
Add SASL-SCRAM, new GetPlugin hook, some fixes

### DIFF
--- a/lib/DJabberd/Caps.pm
+++ b/lib/DJabberd/Caps.pm
@@ -10,7 +10,7 @@ use constant { HASH => 'sha-1' };
 
 sub new {
     my $class = shift;
-    my $self = bless { identity => [], feature => [], form => []}, $class;
+    my $self = bless { identity => [], feature => [], form => [], xml=>'', cap=>'' }, $class;
     foreach my$cap(@_) {
 	next unless(ref($cap));
 	$self->add($cap);
@@ -31,6 +31,8 @@ sub add {
 	}
     }
     return unless(UNIVERSAL::isa($cap,'DJabberd::Caps::Cap'));
+    $self->{cap} = '';
+    $self->{xml} = '';
     push(@{$self->{$cap->type}},$cap);
 }
 
@@ -42,19 +44,25 @@ sub get {
 
 sub as_cap {
     my $self = shift;
-    my $ret = join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{identity}});
-    $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{feature}});
-    $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{form}});
-    return Encode::encode_utf8($ret);
+    if(!$self->{cap}) {
+        my $ret = join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{identity}});
+        $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{feature}});
+        $ret .= join('',map{$_->as_cap}sort{$a cmp $b}@{$self->{form}});
+        $self->{cap} =  Encode::encode_utf8($ret);
+    }
+    return $self->{cap};
 }
 
 sub as_xml {
     my $self = shift;
-    return   Encode::decode_utf8(
+    if(!$self->{xml}) {
+        $self->{xml} = Encode::decode_utf8(
 	     join('',@{$self->{identity}})
 	    .join('',@{$self->{feature}})
 	    .join('',@{$self->{form}})
-    );
+        );
+    }
+    return $self->{xml};
 }
 
 sub digest {

--- a/lib/DJabberd/Connection.pm
+++ b/lib/DJabberd/Connection.pm
@@ -28,6 +28,7 @@ use fields (
             'disconnect_handlers',  # array of coderefs to call when this connection is closed for any reason
             'write_handlers', # array of coderefs to call when someone writes SCALAR ref to the connection (xml)
             'sasl',           # the sasl connection object, when sasl has been or is being negotiated
+	    'bindings'	      # TLS Channel Bindings (RFC 5056) filled by TLS handshake for SASL
             );
 
 our $connection_id = 1;

--- a/lib/DJabberd/Connection/ClientIn.pm
+++ b/lib/DJabberd/Connection/ClientIn.pm
@@ -139,10 +139,13 @@ sub unbind {
         # so if the stanzas 'bounce' or otherwise write back to our full JID,
         # they'll either drop/bounce instead of writing to what will
         # soon be a dead full JID.
-        $self->set_available(0);
+        #$self->set_available(0);
 
         my $unavail = DJabberd::Presence->unavailable_stanza;
-        $unavail->broadcast_from($self);
+        #$unavail->broadcast_from($self);
+        # We need not only to broadcast but also to reset directed presence
+        # and perhaps with AlterPresence hooks.
+        $unavail->process_outbound($self);
     }
 
     if (my $jid = $self->bound_jid) {

--- a/lib/DJabberd/DialbackParams.pm
+++ b/lib/DJabberd/DialbackParams.pm
@@ -1,7 +1,7 @@
 package DJabberd::DialbackParams;
 use strict;
 use Carp;
-use Digest::HMAC_SHA1 qw(hmac_sha1_hex);
+use Digest::SHA qw(hmac_sha1_hex);
 
 use DJabberd::Log;
 our $logger = DJabberd::Log->get_logger();

--- a/lib/DJabberd/Form.pm
+++ b/lib/DJabberd/Form.pm
@@ -3,6 +3,7 @@ package DJabberd::Form;
 use strict;
 use DJabberd::XMLElement;
 use overload '""' => \&as_xml;
+use Carp qw(croak);
 
 our @field_types = (
     'boolean',
@@ -143,27 +144,28 @@ sub as_xml {
 sub as_element {
     my $self = shift;
     my @innards;
-    push(@innards,DJabberd::XMLElement->new('','title',{},[$self->{title}])) if($self->{title});
+    my $ns = 'jabber:x:data';
+    push(@innards,DJabberd::XMLElement->new($ns,'title',{},[$self->{title}])) if($self->{title});
     foreach my$i(@{$self->{instructions}}) {
-	push(@innards,DJabberd::XMLElement->new('','instructions',{},[$i]));
+	push(@innards,DJabberd::XMLElement->new($ns,'instructions',{},[$i]));
     }
     foreach my$v(@{$self->{order}}) {
-	my $attr = { var => $v };
-	$attr->{type} = $self->{fields}->{$v}->{type} if($self->{fields}->{$v}->{type});
-	$attr->{label} = $self->{fields}->{$v}->{label} if($self->{fields}->{$v}->{label});
+	my $attr = { '{}var' => $v };
+	$attr->{'{}type'} = $self->{fields}->{$v}->{type} if($self->{fields}->{$v}->{type});
+	$attr->{'{}label'} = $self->{fields}->{$v}->{label} if($self->{fields}->{$v}->{label});
 	my $kids = [];
-	push(@{$kids},DJabberd::XMLElement->new('','desc',{},[$self->{fields}->{$v}->{desc}])) if($self->{fields}->{$v}->{desc});
-	push(@{$kids},DJabberd::XMLElement->new('','required',{},[])) if($self->{fields}->{$v}->{required});
+	push(@{$kids},DJabberd::XMLElement->new($ns,'desc',{},[$self->{fields}->{$v}->{desc}])) if($self->{fields}->{$v}->{desc});
+	push(@{$kids},DJabberd::XMLElement->new($ns,'required',{},[])) if($self->{fields}->{$v}->{required});
 	foreach my$k(@{$self->{fields}->{$v}->{value}}) {
-	    push(@{$kids},DJabberd::XMLElement->new('','value',{},[$k]));
+	    push(@{$kids},DJabberd::XMLElement->new($ns,'value',{},[$k]));
 	}
 	foreach my$k(@{$self->{fields}->{$v}->{option}}) {
 	    my $oa = {};
 	    $oa->{label} = $k->{label} if($k->{label});
-	    push(@{$kids},DJabberd::XMLElement->new('','option',$oa,[DJabberd::XMLElement->new('','value',{},[$k->{value}])]));
+	    push(@{$kids},DJabberd::XMLElement->new($ns,'option',$oa,[DJabberd::XMLElement->new('','value',{},[$k->{value}])]));
 	}
-	push(@innards,DJabberd::XMLElement->new('','field',$attr,$kids));
+	push(@innards,DJabberd::XMLElement->new($ns,'field',$attr,$kids));
     }
-    return DJabberd::XMLElement->new('','x',{xmlns=>'jabber:x:data'},\@innards);
+    return DJabberd::XMLElement->new($ns,'x',{xmlns=>$ns,($self->{type}?('{}type'=>$self->{type}):())},\@innards);
 }
 1;

--- a/lib/DJabberd/HookDocs.pm
+++ b/lib/DJabberd/HookDocs.pm
@@ -226,4 +226,11 @@ $hook{'GetSASLManager'} = {
     },
 };
 
+$hook{'GetPlugin'} = {
+    des => 'Return plugin instance for given VHost',
+    args => [ "class" => 'Plugin Class/Package name' ],
+    callbacks => {
+	set => [ 'self' ]
+    }
+};
 1;

--- a/lib/DJabberd/JID.pm
+++ b/lib/DJabberd/JID.pm
@@ -93,6 +93,47 @@ my $resourceprep = Unicode::Stringprep->new(
     1,
 );
 
+##
+# Borrowed from Authen::SASL::SASLprep
+sub spacemap {
+    my $ret = {};
+    for(my $pos=0; $pos <= $#Unicode::Stringprep::Prohibited::C12; $pos+=2) {
+	for(my $char = $Unicode::Stringprep::Prohibited::C12[$pos];
+	    defined $Unicode::Stringprep::Prohibited::C12[$pos]
+	    && $char <= $Unicode::Stringprep::Prohibited::C12[$pos];
+	    $char++)
+	{
+	    $ret->{$char} = ' ';
+	}
+    }
+    return $ret;
+}
+
+my $saslprep = Unicode::Stringprep->new(
+    3.2,
+    [
+        \@Unicode::Stringprep::Mapping::B1,
+	spacemap()
+    ],
+    'KC',
+    [
+        \@Unicode::Stringprep::Prohibited::C12,
+        \@Unicode::Stringprep::Prohibited::C21,
+        \@Unicode::Stringprep::Prohibited::C22,
+        \@Unicode::Stringprep::Prohibited::C3,
+        \@Unicode::Stringprep::Prohibited::C4,
+        \@Unicode::Stringprep::Prohibited::C5,
+        \@Unicode::Stringprep::Prohibited::C6,
+        \@Unicode::Stringprep::Prohibited::C7,
+        \@Unicode::Stringprep::Prohibited::C8,
+        \@Unicode::Stringprep::Prohibited::C9,
+    ],
+    1,
+);
+
+sub saslprep {
+    return eval { $saslprep->(@_) };
+}
 
 # returns DJabberd::JID object, or undef on failure due to invalid format
 sub new {

--- a/lib/DJabberd/SASL/AuthenSASL.pm
+++ b/lib/DJabberd/SASL/AuthenSASL.pm
@@ -41,7 +41,39 @@ sub register {
                 $xml_mechanisms .= "<mechanism>EXTERNAL</mechanism>";
             }
         }
-        $xml_mechanisms .= join "", map { "<mechanism>$_</mechanism>" } @mech;
+	my @plus = grep {$_ =~ /^SCRAM-.+-PLUS$/}@mech;
+	my @rest = grep {$_ !~ /^SCRAM-.+-PLUS$/}@mech;
+	if (@plus && ($conn->ssl || 0) > 0) {
+	    my $buf;
+	    my $rv = Net::SSLeay::get_peer_finished($conn->ssl, $buf);
+	    if($rv > 0) {
+		$conn->{bindings}->{tls_unique} = $buf;
+	    } else {
+		$conn->log->debug("Failed to obtain unique bindings: $rv");
+		Net::SSLeay::die_if_ssl_error("tls-unique");
+	    }
+	    $buf = Net::SSLeay::export_keying_material($conn->ssl, 32, "EXPORTER-Channel-Binding", "");
+	    $conn->{bindings}->{tls_exporter} = $buf if($buf);
+	    if($conn->{bindings} && grep{$_}values(%{$conn->{bindings}})) {
+		$xml_mechanisms .= join"",map{"<mechanism>$_</mechanism>"}@plus;
+		$xml_mechanisms .= "<sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'>";
+		$xml_mechanisms .= join("",map{"<channel-binding type='$_'/>"}
+						map{y/_/-/;$_}
+							grep{$conn->{bindings}->{$_}}
+								keys(%{$conn->{bindings}}));
+		$xml_mechanisms .= "</sasl-channel-binding>";
+	    } else {
+		$conn->log->debug("Suppressing mechs[no-cb]: ".join(", ",@plus));
+	    }
+	} elsif(@plus) {
+	    $conn->log->debug("Suppressing mech[no-ssl]: ".join(", ",@plus));
+	} else {
+	    if(ref($conn->{bindings}) && keys(%{$conn->{bindings}})) {
+		# Disable bindings as we are not advertising -PLUS
+		$conn->{bindings} = undef;
+	    }
+	}
+        $xml_mechanisms .= join "", map { "<mechanism>$_</mechanism>" } @rest;
         $xml_mechanisms .= "<optional/>" if $plugin->is_optional;
         $xml_mechanisms .= "</mechanisms>";
         $cb->stanza($xml_mechanisms);
@@ -59,6 +91,367 @@ sub register {
 	$cb->decline;
     }) if($plugin->mechanisms->{EXTERNAL});
 }
+
+##
+# RFC 6120 Conformance Requirements [section 15] mandates support for SASL
+# SCRAM-SHA-1[-PLUS] at the least for both client and server. Authen::SASL
+# does not support it so let's patch it up
+package Authen::SASL::Perl::SCRAM_SHA_1_PLUS;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl';
+use Net::SSLeay;
+use Digest::SHA;
+use MIME::Base64 qw/encode_base64url encode_base64 decode_base64/;
+use Authen::SASL::SASLprep;
+
+# MonkeyPathing Authen::SASL
+$INC{'Authen/SASL/Perl/SCRAM_SHA_1_PLUS.pm'} = __FILE__;
+
+sub mechanism { "SCRAM-SHA-1-PLUS" }
+sub _order { 5 }
+
+my %secflags = (
+  noplaintext => 1,
+  noanonymous => 1,
+);
+sub _secflags {
+  shift;
+  scalar grep { $secflags{$_} } @_;
+}
+
+sub _init {
+    my ($class, $self) = @_;
+    bless $self, $class;
+
+    # 128biit seems to be a good half-entropy
+    my $rnd = $self->rnd(16);
+    if($rnd) {
+	$self->property('_nonce', encode_base64url($rnd));
+	return $self;
+    }
+}
+
+sub _init_server {
+    my ($self, $opts) = @_;
+    $self->{tlsbinndings} = ($opts->{tlsbindings} || 0) if(ref($opts) eq 'HASH');
+}
+
+sub can_bind {
+    my ($self) = @_;
+    return ($self->{tlsbindings} || 0);
+}
+
+sub rnd {
+    my ($self, $len) = @_;
+    my ($rnd, $rv);
+    $rv = Net::SSLeay::RAND_bytes($rnd, $len);
+    if($rv) {
+	return $rnd;
+    }
+}
+
+sub _encode {
+    my $n = eval { saslprep($_[0], 1) };
+    return undef unless($n);
+    $n =~ s/,/=2c/g;
+    $n =~ s/=/=3d/g;
+    return $n;
+}
+
+sub client_start {
+    my ($self,$cb_type) = @_;
+
+    $self->set_error(1);
+    my $user = $self->_call('user');
+    return 'Missing username' unless($user);
+    $user = _encode($user);
+    return 'Invalid username' unless($user);
+
+    my $cb_data = $self->_call('binding',$cb_type);
+    my $gs2_flag;
+    if($cb_data) {
+	$gs2_flag = "p=$cb_type";
+    } elsif(defined $cb_type) {
+	$gs2_flag = 'y,,';
+	$cb_data = "";
+    } else {
+	$gs2_flag = 'n,,';
+	$cb_data = "";
+    }
+
+    $self->set_error(0);
+    my $client_first_bare = "n=$user,r=".$self->property('_nonce');
+    $self->property('gs2_flag' => $gs2_flag);
+    $self->property("cb_data" => $cb_data);
+    $self->property('client_first_bare' => $client_first_bare);
+    return $gs2_flag.$client_first_bare;
+}
+
+sub _decode {
+    $_[0] =~ s/=2c/,/gi;
+    $_[0] =~ s/=3d/=/gi;
+    return undef if($_[0] =~ /=/);
+    return eval { saslprep($_[0], 1) };
+}
+
+sub server_start {
+    my ($self,$auth,$cb) = @_;
+
+    # presumption of error
+    $self->set_error(1);
+
+    # Essentials
+    return $cb->('Internal Server Error') unless($self->callback('getsecret'));
+    return $cb->('Empty auth request') unless($auth);
+
+    my @gs = split(',',$auth);
+    return $cb->('Malformed auth request') if($#gs < 3);
+
+    # binding mangling, bail
+    return $cb->('Channel binding downgrade') if($self->can_bind && $gs[0] eq 'y');
+    my $cb_data = '';
+    if($gs[0] =~ /^p=(.+)/) {
+	$cb_data = $self->_call('getbinding',$1);
+	return $cb->('Unsupported channel binding type') unless($cb_data);
+    }
+
+    return $cb->('Invalid or missing authn identity') unless($gs[2] =~ /^n=(.+)/);
+
+    my $user = _decode($1);
+    return $cb->('Invalid or empty user name') unless($user);
+
+    return $cb->('Invalid or missing random nonce') unless($gs[3] =~ /^r=(.+)/);
+    return $cb->('Unsupported Digest Algorithm') unless($self->hash("hush"));
+
+    # Fill up the context and dash for the pass
+    #$self->property('user' => $user);
+    $self->property('cb_data' =>$cb_data);
+    $self->property('c_nonce' => $1);
+    $self->property('gs2_flag' => $gs[0].",".$gs[1].",");
+    $self->property('client_first_bare' => $gs[2].','.$gs[3]);
+    $self->_call('getsecret',{user=>$user}, sub { $cb->($self->server_continue(shift, $user))});
+}
+
+sub server_continue {
+    my ($self, $pass, $user) = @_;
+
+    return 'User not found or empty password' unless($pass);
+
+    # Clear to continue
+    $self->{answer}{user} = $user;
+    $self->set_error(0);
+    my ($salt, $iter, $stored_key, $server_key);
+    if($pass =~ /(\d{4,8}),([A-Za-z0-9+\/]{6,}={0,3}),([A-Za-z0-9+\/]{6,}={0,3}),([A-Za-z0-9+\/]{6,}={0,3})/) {
+	# Use pre-salted derived keys
+	$iter = 0 + $1;
+	$salt = decode_base64($2);
+	$stored_key = decode_base64($3);
+	$server_key = decode_base64($4);
+    } else {
+	# Generating new derived keys with random salt
+	$iter = 8192;
+	$salt = $self->rnd(8);
+	my $salted_pwd = $self->hi($pass, $salt, $iter);
+	my $client_key = $self->hmac($salted_pwd, "Client Key");
+	$stored_key = $self->hash($client_key);
+	$server_key = $self->hmac($salted_pwd, "Server Key");
+    }
+    my $server_first = 'r='.$self->property('c_nonce').$self->property('_nonce')
+	    .',s='.encode_base64($salt,'').",i=$iter";
+    $self->property("stored_key" => $stored_key);
+    $self->property("server_key" => $server_key);
+    $self->property('server_first' => $server_first);
+    return $server_first;
+}
+
+##
+# Wipe the state clean
+sub reset {
+    my ($self) = @_;
+    $self->property('_nonce' => undef);
+    $self->property('cb_data' => undef);
+    $self->property('gs2_flag' => undef);
+    $self->property('c_nonce' => undef);
+    $self->property('client_first_bare' => undef);
+    $self->property('server_first' => undef);
+    $self->property('stored_key' => undef);
+    $self->property('server_key' => undef);
+    $self->property('server_sig' => undef);
+    $self->set_error(undef);
+    $self->{answer} = {};
+}
+
+# U1		  := HMAC(str, salt + INT(1))
+# U2		  := HMAC(str, U1)
+# Ui		  := HMAC(str, Ui-1)
+# Hi(str, salt, i):= U1 XOR U2 XOR ... XOR Ui
+# SaltedPassword  := Hi(Normalize(password), salt, i)
+# ClientKey       := HMAC(SaltedPassword, "Client Key")
+# StoredKey       := H(ClientKey)
+# AuthMessage     := client-first-message-bare + ","
+#		   + server-first-message + ","
+#		   + client-final-message-without-proof
+# ClientSignature := HMAC(StoredKey, AuthMessage)
+# ClientProof     := ClientKey XOR ClientSignature
+# ClientKey	  := ClientProof XOR ClientSignature
+# ServerKey       := HMAC(SaltedPassword, "Server Key")
+# ServerSignature := HMAC(ServerKey, AuthMessage)
+#
+# DoveAdm PW SCRAM Scheme
+# {SCHEME},iter,b64(salt),b64(StoredKey),b64(ServerKey)
+
+
+sub hmac {
+    my ($self, $key, $data) = @_; # Note argument swap
+    return $self->{_hmac}->($data, $key) if($self->{_hmac});
+
+    my $mech = $self->mechanism();
+    if(index($mech, "SHA-512", 6)==6) {
+	$self->{_hmac} = \&Digest::SHA::hmac_sha512;
+    } elsif(index($mech, "SHA-256", 6)==6) {
+	$self->{_hmac} = \&Digest::SHA::hmac_sha256;
+    } elsif(index($mech, "SHA-1", 6) == 6) {
+	$self->{_hmac} = \&Digest::SHA::hmac_sha1;
+    } else {
+	$self->{_hmac} = sub { undef };
+    }
+    return $self->{_hmac}->($data, $key);
+}
+sub hash {
+    my ($self, $data) = @_;
+    return $self->{_hash}->($data) if($self->{_hash});
+
+    my $mech = $self->mechanism();
+    if(index($mech, "SHA-512", 6)==6) {
+	$self->{_hash} = \&Digest::SHA::sha512;
+    } elsif(index($mech, "SHA-256", 6)==6) {
+	$self->{_hash} = \&Digest::SHA::sha256;
+    } elsif(index($mech, "SHA-1", 6) == 6) {
+	$self->{_hash} = \&Digest::SHA::sha1;
+    } else {
+	$self->{_hash} = sub { undef };
+    }
+    return $self->{_hash}->($data);
+}
+
+sub hi {
+    my ($self, $data, $salt, $iter) = @_;
+    my $one = pack('N',1); # "\0\0\0\1";
+    my $U = $self->hmac($data, $salt.$one);
+    my $Hi = $U;
+    for my $i (2..$iter) {
+	$U = $self->hmac($data, $U);
+	$Hi ^= $U;
+    }
+    return $Hi;
+}
+
+sub client_step {
+    my ($self,$server_first) = @_;
+
+    return $self->client_last($server_first) if($self->property('server_sig'));
+
+    $self->set_error(1);
+    return 'Malformed challenge'
+	unless($server_first =~ /r=([^,]+),s=([^,]+),i=(\d+)$/);
+    my ($nonce, $salt, $iter) = ($1, decode_base64($2), int($3));
+
+    return 'Tampered Nonce' unless(rindex($nonce, $self->property('_nonce'), 0) == 0);
+    return 'Too small iteration count' if(int($iter) < 4096);
+    return 'Empty or small salt string' unless($salt && length($salt)>3);
+    $self->set_error(0);
+
+    my $c = encode_base64($self->property("gs2_flag").$self->property("cb_data"),'');
+    my $client_last_bare = "c=$c,r=$nonce";
+    my $salted_pwd = $self->hi($self->_call('pass'), $salt, $iter);
+    my $client_key = $self->hmac($salted_pwd, "Client Key");
+    my $stored_key = $self->hash($client_key);
+    my $auth_msg = $self->property("client_first_bare").",$server_first,$client_last_bare";
+    my $client_sig = $self->hmac($stored_key, $auth_msg);
+    my $client_prf = $client_key ^ $client_sig;
+    my $server_key = $self->hmac($salted_pwd, "Server Key");
+    my $server_sig = $self->hmac($server_key, $auth_msg);
+    $self->property("server_sig" => $server_sig);
+    return "$client_last_bare,p=".encode_base64($client_prf,'');
+}
+
+sub server_step {
+    my ($self, $client_last, $cb) = @_;
+
+    $self->set_error(1);
+    return $cb->('Malformed packet: parse') unless($client_last =~ /c=([^,]+),r=([^,]+),p=([^,]+)/);
+
+    my $stored_key = $self->property('stored_key');
+    return $cb->('Malformed packet: state') unless($stored_key);
+
+    my ($cb_proof, $nonce, $cl_proof) = ($1, $2, decode_base64($3));
+    return $cb->('Authentication Failed: nonce') unless($nonce eq $self->property('c_nonce').$self->property('_nonce'));
+    my $our_cb = encode_base64($self->property('gs2_flag').$self->property('cb_data'), '');
+    return $cb->('Authentication Failed: cbind') unless($cb_proof eq $our_cb);
+
+    my $auth_msg = $self->property('client_first_bare').','.$self->property('server_first').",c=$cb_proof,r=$nonce";
+    my $client_sig = $self->hmac($stored_key, $auth_msg);
+    my $client_key = $client_sig ^ $cl_proof;
+    return $cb->('Authentication Failed: pass') unless($stored_key eq $self->hash($client_key));
+
+    my $server_sig = $self->hmac($self->property('server_key'), $auth_msg);
+    $self->set_error(undef);
+    $self->set_success();
+    $cb->('v='.encode_base64($server_sig,''));
+    $self->reset();
+}
+
+sub client_last {
+    my ($self,$server_last) = @_;
+
+    $self->set_error(1);
+    return 'Malformed packet: parse' unless($server_last =~ /v=([^,]+)/);
+    my $server_sig = decode_base64($1);
+    return 'Malformed packet: data' unless($server_sig eq $self->property('server_sig'));
+    $self->reset();
+    $self->set_success();
+}
+
+package Authen::SASL::Perl::SCRAM_SHA_1;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl::SCRAM_SHA_1_PLUS';
+sub mechanism { "SCRAM-SHA-1" }
+sub _order { 4 }
+$INC{'Authen/SASL/Perl/SCRAM_SHA_1.pm'} = __FILE__;
+
+package Authen::SASL::Perl::SCRAM_SHA_256_PLUS;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl::SCRAM_SHA_1_PLUS';
+sub mechanism { "SCRAM-SHA-256-PLUS" }
+sub _order { 7 }
+$INC{'Authen/SASL/Perl/SCRAM_SHA_256_PLUS.pm'} = __FILE__;
+
+package Authen::SASL::Perl::SCRAM_SHA_256;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl::SCRAM_SHA_1_PLUS';
+sub mechanism { "SCRAM-SHA-256" }
+sub _order { 6 }
+$INC{'Authen/SASL/Perl/SCRAM_SHA_256.pm'} = __FILE__;
+
+package Authen::SASL::Perl::SCRAM_SHA_512_PLUS;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl::SCRAM_SHA_1_PLUS';
+sub mechanism { "SCRAM-SHA-512-PLUS" }
+sub _order { 9 }
+$INC{'Authen/SASL/Perl/SCRAM_SHA_512_PLUS.pm'} = __FILE__;
+
+package Authen::SASL::Perl::SCRAM_SHA_512;
+use strict;
+use warnings;
+use base 'Authen::SASL::Perl::SCRAM_SHA_1_PLUS';
+sub mechanism { "SCRAM-SHA-512" }
+sub _order { 8 }
+$INC{'Authen/SASL/Perl/SCRAM_SHA_512.pm'} = __FILE__;
 
 1;
 

--- a/lib/DJabberd/SASL/Manager/AuthenSASL.pm
+++ b/lib/DJabberd/SASL/Manager/AuthenSASL.pm
@@ -75,6 +75,14 @@ sub manager_implementation {
                     );
                 }
             },
+	    getbinding => sub {
+		my ($sasl, $type) = @_;
+		$type =~ s/-/_/g;
+		$conn->log->debug("Querying cb-type $type, got ".join(",",grep{$conn->{bindings}{$_}}keys(%{$conn->{bindings}})));
+		return $conn->{bindings}{$type}
+		    if($conn->{bindings} && exists $conn->{bindings}{$type});
+		return undef;
+	    },
         },
     );
     return $saslmgr;

--- a/lib/DJabberd/Stanza/SASL.pm
+++ b/lib/DJabberd/Stanza/SASL.pm
@@ -109,6 +109,7 @@ sub handle_auth {
 
     ## we don't support it for now
     my $opts = { no_integrity => 1 };
+    $opts->{tlsbindings} = $conn->{bindings};
     $saslmgr->mechanism($mechanism);
     my $sasl_conn = $saslmgr->server_new("xmpp", $vhost->server_name, $opts);
     $conn->{sasl} = $sasl_conn;
@@ -262,6 +263,7 @@ sub send_reply {
 
     if (my $error = $sasl_conn->error) {
         $self->send_failure("not-authorized" => $conn);
+	$conn->log->debug("SASL Error: $error, $challenge");
     }
     elsif ($sasl_conn->is_success) {
         $self->ack_success($sasl_conn, $challenge => $conn);

--- a/t/lib/djabberd-test.pl
+++ b/t/lib/djabberd-test.pl
@@ -38,7 +38,7 @@ sub once_logged_in {
 
 sub two_parties {
     my $cb = shift;
-    my $ipv6 = shift || 0;
+    my $ipv6 = shift || 1;
 
     if ($ENV{WILDFIRE_S2S}) {
         two_parties_wildfire_to_local($cb);
@@ -50,9 +50,9 @@ sub two_parties {
         return;
     }
 
-    two_parties_one_server($cb);
+    two_parties_one_server($cb,@_);
     sleep 1;
-    two_parties_s2s($cb,$ipv6);
+    two_parties_s2s($cb,$ipv6,@_);
     sleep 1;
 }
 
@@ -104,7 +104,7 @@ sub two_parties_one_server {
     my $cb = shift;
 
     my $server = Test::DJabberd::Server->new(id => 1);
-    $server->start;
+    $server->start(@_);
 
     my $pa = Test::DJabberd::Client->new(server => $server, name => "partya");
     my $pb = Test::DJabberd::Client->new(server => $server, name => "partyb");
@@ -121,8 +121,8 @@ sub two_parties_s2s {
     my $server2 = Test::DJabberd::Server->new(id => 2, ipv6 => $ipv6, );
     $server1->link_with($server2);
     $server2->link_with($server1);
-    $server1->start;
-    $server2->start;
+    $server1->start(@_);
+    $server2->start(@_);
 
     my $pa = Test::DJabberd::Client->new(server => $server1, name => "partya");
     my $pb = Test::DJabberd::Client->new(server => $server2, name => "partyb");
@@ -260,7 +260,7 @@ sub standard_plugins {
     my $self = shift;
     my @sasl;
     @sasl = ( DJabberd::SASL::AuthenSASL->new(
-                mechanisms => "LOGIN PLAIN DIGEST-MD5",
+                mechanisms => "LOGIN PLAIN DIGEST-MD5 SCRAM-SHA-1",
                 optional   => "yes",
             )) if $HAS_SASL;
     return [


### PR DESCRIPTION
This MR adds implementation of (mandatory to implement by RFC6120) SASL-SCRAM-SHA* implementation and introduces new hook.
The SASL is actually implemented as monkey-patch on top of Authen::SASL which is ugly. But it works. (TODO: upstream it).
The patch adds server- and client-side implementation (so can be upstreamed actually) for SHA1, SHA2 and -PLUS methods.
Also adds tls channel bindings to support -PLUS variants - extracts binding data from SSLeay layer.
To avoid pulling yet another dependency (Authen::SASL::SASLprep) which happens to be not in the main repo on Arch - the saslprep implementation is borrowed from there and added to DJabberd::JID to complement similar jidprep implementation.

The newly introduced hook is supposed to cover the need for plugin-to-plugin communication. Mainly it is intended for (and enables) PEP Storage for bookmarks and avatars.

To speed up a bit Caps processing (which is used heavily in PEP) a new caps cache is introduced to avoid re-calculation of digest (which implies serialisation) on each call.

And several fixes for form serialisation and directed presence cleanup.

Closes #40 