### PR TITLE
Various Fixes

### DIFF
--- a/lib/DJabberd.pm
+++ b/lib/DJabberd.pm
@@ -482,7 +482,7 @@ sub _start_server {
             if(lc($1) eq 'g') {
                 my ($gn,undef,$gid,$mm) = getgrnam($2);
                 my $un = getpwuid($<);
-                $logger->debug("Need to chgrp $sock to $gn/$gid: $un should be in '$mm' or $< == 0");
+                $logger->debug("Need to chgrp $sock to $gn/$gid: $un should be in members($mm) or EUID[$<] == 0");
                 if($<==0 || grep{$_ eq $un}split('\s+',$mm)) {
                     chown(-1, $gid, $sock) or $logger->logdie("Error changing group: $@\n");
                     if(!($stat[2] & 020)) {

--- a/lib/DJabberd/Delivery/S2S.pm
+++ b/lib/DJabberd/Delivery/S2S.pm
@@ -37,6 +37,9 @@ sub deliver {
         return $cb->declined;
 
     $DJabberd::Stats::counter{deliver_s2s}++;
+
+    $stanza->replace_ns("jabber:client", "jabber:server");
+
     $out_queue->queue_stanza($stanza, $cb);
 }
 

--- a/lib/DJabberd/Form.pm
+++ b/lib/DJabberd/Form.pm
@@ -21,10 +21,10 @@ sub new {
     my $class = shift;
     my $self;
     # Try to create from XMLElement tree
-    if(@_ && $_[0] && ref($_[0]) && UNIVERSAL::isa($_[0],'DJabberd::XMLElement') && $_[0]->element eq '{jabber:x:data}x' && $_[0]->children) {
+    if(@_ && $_[0] && ref($_[0]) && UNIVERSAL::isa($_[0],'DJabberd::XMLElement') && $_[0]->element eq '{jabber:x:data}x' && ($_[0]->children || $_[0]->attr('{}type') eq 'cancel')) {
 	$self = from_element($_[0]);
     } else {
-	# Or from raw struct: new('type',[{var=>"var",value=>["val"]},...],[title=>"title",][instructions=>"instructions"]);
+	# Or from raw struct: new('type',[{var=>"var",value=>["val"],type=>"type",option=>[{value=>"val",label=>"label"},...]},...],[title=>"title",][instructions=>"instructions"]);
 	my $type = shift;
 	my $fields = shift;
 	my %args = @_;

--- a/lib/DJabberd/Form.pm
+++ b/lib/DJabberd/Form.pm
@@ -109,7 +109,9 @@ sub form_type {
     my $self = shift;
     my $type = '';
     if(exists $self->{fields}->{FORM_TYPE}) {
-	if($self->{fields}->{FORM_TYPE}->{type} && $self->{fields}->{FORM_TYPE}->{type} eq 'hidden') {
+	if(($self->{fields}->{FORM_TYPE}->{type} && $self->{fields}->{FORM_TYPE}->{type} eq 'hidden')
+	  || $self->{type} eq 'submit')
+	{
 	    $type = $self->{fields}->{FORM_TYPE}->{value}->[0];
 	}
     }

--- a/lib/DJabberd/Presence.pm
+++ b/lib/DJabberd/Presence.pm
@@ -461,10 +461,17 @@ sub _process_outbound_available {
                                        $self->_process_outbound_available($conn, 1);
                                    },
                                },
+                               # Enable fall-through signal-like notifications where
+                               # all subscribers decline it all the way through
+				fallback => sub {
+                                    return if $conn->{closed} > 0;
+				    $self->_process_outbound_available($conn, 1);
+				},
                                );
         return;
     }
 
+    $conn->log->debug($self->as_xml);
     if ($self->is_directed) {
         $conn->add_directed_presence($self->to_jid);
         $self->deliver;
@@ -497,11 +504,11 @@ sub _process_outbound_unavailable {
                                        $self->_process_outbound_unavailable($conn, 1);
                                    },
                                },
-                               # No idea how it was supposed to be working
-                               # but this way it does
-                               fallback => sub {
-                                   $self->_process_outbound_unavailable($conn, 1);
-                               },
+                               # Enable fall-through signal-like notifications where
+                               # all subscribers decline it all the way through
+				fallback => sub {
+				    $self->_process_outbound_unavailable($conn, 1);
+				},
                                );
         return;
     }

--- a/lib/DJabberd/Presence.pm
+++ b/lib/DJabberd/Presence.pm
@@ -431,14 +431,13 @@ sub broadcast_from {
         }
 
         # For the purpose of presence broadcasting
-        # we act as if all of the other resources
+        # we act as if all of the bound resources
         # for this bare JID are on the roster.
         # This means that resources of the same
         # JID are aware of each other and can send
         # messages to each other, etc.
         foreach my $otherconn ($vhost->find_conns_of_bare($from_jid)) {
             my $to_jid = $otherconn->bound_jid;
-            next if $from_jid->eq($to_jid);
             my $dpres = $self->clone;
             $dpres->set_to($to_jid);
             $dpres->set_from($from_jid);

--- a/lib/DJabberd/RosterStorage.pm
+++ b/lib/DJabberd/RosterStorage.pm
@@ -18,6 +18,9 @@ use DJabberd::RosterItem;
     }
 }
 
+# let others be
+sub run_after { qw(ALL) }
+
 # don't override, or at least call SUPER to this if you do.
 sub register {
     my ($self, $vhost) = @_;

--- a/lib/DJabberd/Stanza.pm
+++ b/lib/DJabberd/Stanza.pm
@@ -173,7 +173,8 @@ sub make_error_response {
             "{}type" => $type,
         },
         [
-            ref $error ? $error : new DJabberd::XMLElement("urn:ietf:params:xml:ns:xmpp-stanzas", $error, {}, []),
+            ref $error ? $error : new DJabberd::XMLElement("urn:ietf:params:xml:ns:xmpp-stanzas", $error,
+					{xmlns=>'urn:ietf:params:xml:ns:xmpp-stanzas'}, []),
         ],
     );
 

--- a/lib/DJabberd/VHost.pm
+++ b/lib/DJabberd/VHost.pm
@@ -380,12 +380,12 @@ sub register_hook {
         my $aa = $a->{pkg}->can('run_after');
         my $bb = $b->{pkg}->can('run_before');
         my $ba = $b->{pkg}->can('run_after');
-        return -1 if($ab && grep{$_ eq 'ALL'}$ab->($phase) && !($bb && grep{$_ eq 'ALL'}$bb->($phase)));
+        return -1 if($ab && (grep{$_ eq 'ALL'}$ab->($phase)) && !($bb && grep{$_ eq 'ALL'}$bb->($phase)));
         return -1 if($ab && grep{$_ eq $b->{pkg}}$ab->($phase));
         return -1 if($ba && grep{$_ eq $a->{pkg}}$ba->($phase));
         return +1 if($aa && grep{$_ eq $b->{pkg}}$aa->($phase));
         return +1 if($bb && grep{$_ eq $a->{pkg}}$bb->($phase));
-        return +1 if($aa && grep{$_ eq 'ALL'}$aa->($phase) && !($ba && grep{$_ eq 'ALL'}$ba->($phase)));
+        return +1 if($aa && (grep{$_ eq 'ALL'}$aa->($phase)) && !($ba && grep{$_ eq 'ALL'}$ba->($phase)));
         #$logger->debug('Keeping the ordering for '.$a->{pkg}.' and '.$b->{pkg});
         return 0;
     };

--- a/lib/DJabberd/XMLElement.pm
+++ b/lib/DJabberd/XMLElement.pm
@@ -156,7 +156,7 @@ sub as_xml {
     }
 
     my $attr_str = "";
-    my $attr = $self->{attrs};
+    my $attr = { %{$self->{attrs}} };
 
     $nsmap->{xmlns} = 'http://www.w3.org/2000/xmlns';
     $nsmap->{'http://www.w3.org/2000/xmlns'} = 'xmlns';

--- a/t/directed-presence-v6.t
+++ b/t/directed-presence-v6.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 28;
+use Test::More tests => 34;
 use lib 't/lib';
 require 'djabberd-test.pl';
 
@@ -9,7 +9,9 @@ two_parties(sub {
     $pa->login;
     $pb->login;
     $pa->send_xml("<presence/>");
+    like($pa->recv_xml, qr{from=['"]$pa}, "Self presence check");
     $pb->send_xml("<presence/>");
+    like($pb->recv_xml, qr{from=['"]$pb}, "Self presence check");
 
     select(undef, undef, undef, 0.25);
 
@@ -27,6 +29,7 @@ two_parties(sub {
     like($xml, qr{presence});
 
     $pa->send_xml(qq{<presence><show>this should not go to B</show></presence>});
+    like($pa->recv_xml, qr/><show>this should not go to B</, "pa got own presence");
     $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");
     like($pb->recv_xml, qr/type=.chat.*Hello.*I am \Q$pa\E/, "pb got pa's message");
 

--- a/t/directed-presence.t
+++ b/t/directed-presence.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 28;
+use Test::More tests => 34;
 use lib 't/lib';
 require 'djabberd-test.pl';
 
@@ -9,7 +9,9 @@ two_parties(sub {
     $pa->login;
     $pb->login;
     $pa->send_xml("<presence/>");
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pb->send_xml("<presence/>");
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
 
     select(undef, undef, undef, 0.25);
 
@@ -27,6 +29,7 @@ two_parties(sub {
     like($xml, qr{presence});
 
     $pa->send_xml(qq{<presence><show>this should not go to B</show></presence>});
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");
     like($pb->recv_xml, qr/type=.chat.*Hello.*I am \Q$pa\E/, "pb got pa's message");
 

--- a/t/exchange-messages.t
+++ b/t/exchange-messages.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 10;
+use Test::More tests => 14;
 use lib 't/lib';
 
 require 'djabberd-test.pl';
@@ -18,7 +18,9 @@ two_parties(sub {
 
     # now pa/pb send presence to become available resources
     $pa->send_xml("<presence/>");
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pb->send_xml("<presence/>");
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
     select(undef, undef, undef, 0.25);
 
     # PA to PB

--- a/t/handle-stanza-hook.t
+++ b/t/handle-stanza-hook.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 3;
+use Test::More tests => 4;
 use lib 't/lib';
 require 'djabberd-test.pl';
 
@@ -55,6 +55,7 @@ my $client = Test::DJabberd::Client->new(server => $server, name => "client");
 {
     $client->login;
     $client->send_xml("<presence/>");
+    like($client->recv_xml, qr/from=["']$client/, "own presence check");
     
     select(undef, undef, undef, 0.25);
     

--- a/t/inband-reg.t
+++ b/t/inband-reg.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 7;
+use Test::More tests => 8;
 use lib 't/lib';
 BEGIN {  $ENV{LOGLEVEL} ||= "FATAL" }
 BEGIN { require 'djabberd-test.pl' }
@@ -52,6 +52,7 @@ my $client = Test::DJabberd::Client->new(server => $server, name => "testuser");
 $client->login("jabberwocky");
 
 $client->send_xml("<presence/>");
+like($client->recv_xml, qr/<presence\s+.*from=["']$client/, "own presence check");
 $client->send_xml("<message type='chat' to='$client'>Hello myself!</message>");
 like($client->recv_xml, qr/Hello myself/, "client got own message");
 

--- a/t/iq-exchange.t
+++ b/t/iq-exchange.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 4;
+use Test::More tests => 8;
 use lib 't/lib';
 
 require 'djabberd-test.pl';
@@ -10,7 +10,9 @@ two_parties(sub {
     $pa->login;
     $pb->login;
     $pa->send_xml("<presence/>");
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pb->send_xml("<presence/>");
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
     select(undef,undef,undef,0.25);
 
     my $ja = DJabberd::JID->new($pa.'/'.$pb->resource);

--- a/t/mutual-add-and-presence.t
+++ b/t/mutual-add-and-presence.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 use strict;
-use Test::More tests => 36;
+use Test::More tests => 44;
 use lib 't/lib';
 require 'djabberd-test.pl';
 
@@ -8,10 +8,12 @@ two_parties(sub {
     my ($pa, $pb) = @_;
     $pa->login;
     $pa->send_xml(qq{<presence><status>Init-A-Pres</status></presence>});
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pa->get_roster;  # pb isn't going to request its roster.
 
     $pb->login;
     $pb->send_xml(qq{<presence><status>InitPres</status></presence>});
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
 
     $pa->send_xml(qq{<iq type='set' id='set1'>
   <query xmlns='jabber:iq:roster'>
@@ -73,6 +75,7 @@ two_parties(sub {
 
     # now PA is subscribed to PB.  so let's make PB change its status
     $pb->send_xml(qq{<presence><status>PresVer2</status></presence>});
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
     $xml = $pa->recv_xml;
     like($xml, qr/<presence.+\bfrom=.$pb.+PresVer2/s, "partya got presver2 presence of pb");
 
@@ -111,6 +114,7 @@ two_parties(sub {
 
 
     $pa->send_xml(qq{<presence><status>I_am_A</status></presence>});
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
     $pb->send_xml(qq{<presence><status>I_am_B</status></presence>});
     like($pa->recv_xml, qr/I_am_B/, "a got b's presence");
     like($pb->recv_xml, qr/I_am_A/, "b got a's presence");

--- a/t/quirk-libgaim-iqerrorfrom.t
+++ b/t/quirk-libgaim-iqerrorfrom.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use Test::More tests => 14;
+use Test::More tests => 22;
 use lib 't/lib';
 
 BEGIN {
@@ -32,7 +32,9 @@ sub run_test {
         $pa->login;
         $pb->login;
         $pa->send_xml("<presence/>");
+    like($pa->recv_xml, qr/from=["']$pa/, "own presence check");
         $pb->send_xml("<presence/>");
+    like($pb->recv_xml, qr/from=["']$pb/, "own presence check");
 
         my $xml;
 

--- a/t/s2s-no-dialback-to.t
+++ b/t/s2s-no-dialback-to.t
@@ -19,7 +19,9 @@ sub test {
         $pa->login;
         $pb->login;
         $pa->send_xml("<presence/>");
+	$pa->recv_xml;
         $pb->send_xml("<presence/>");
+	$pb->recv_xml;
 
         # PA to PB
         $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");

--- a/t/sasl-login.t
+++ b/t/sasl-login.t
@@ -23,7 +23,9 @@ my $login_and_be = sub {
     my $jid = $pa->sasl_login($sasl, $res);
     $pb->login;
     $pa->send_xml("<presence/>");
+	$pa->recv_xml;
     $pb->send_xml("<presence/>");
+	$pb->recv_xml;
 
     select(undef,undef,undef,0.25); # doh
     my $jb = DJabberd::JID->new($pb.'/'.$pb->resource);
@@ -94,7 +96,9 @@ my $login_and_be = sub {
 	my $jid = $pa->sasl_login($sasl, 'yann');
 	my $jib = $pb->sasl_login($sbsl, $pb->resource);
 	$pa->send_xml("<presence/>");
+	$pa->recv_xml;
 	$pb->send_xml("<presence/>");
+	$pb->recv_xml;
 
 	select(undef,undef,undef,0.25); # doh
 	my $jb = DJabberd::JID->new($pb.'/'.$pb->resource);

--- a/t/server_die.t
+++ b/t/server_die.t
@@ -10,7 +10,9 @@ two_parties_s2s(sub {
     $pa->login;
     $pb->login;
     $pa->send_xml("<presence/>");
+	$pa->recv_xml;
     $pb->send_xml("<presence/>");
+	$pb->recv_xml;
 
     $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");
     like($pb->recv_xml, qr/type=.chat.*Hello.*I am \Q$pa\E/, "pb got pa's message");
@@ -22,6 +24,7 @@ two_parties_s2s(sub {
     $server->start;
     $pa->login;
     $pa->send_xml("<presence/>");
+	$pa->recv_xml;
 
     $pa->send_xml("<message type='chat' to='$pb'>Hello.  I am $pa.</message>");
     like($pb->recv_xml, qr/type=.chat.*Hello.*I am \Q$pa\E/, "pb got pa's message");

--- a/t/unsubscribe.t
+++ b/t/unsubscribe.t
@@ -10,7 +10,9 @@ two_parties(sub {
     $pb->login;
 
     $pa->initial_presence;
+	$pa->recv_xml;
     $pb->initial_presence;
+	$pb->recv_xml;
     $pa->get_roster;
     $pb->get_roster;
 
@@ -23,10 +25,12 @@ two_parties(sub {
 
 
     $pb->send_xml(qq{<presence><status>PresVer2</status></presence>});
+	$pb->recv_xml;
     my $xml = $pa->recv_xml;
     like($xml, qr/<presence.+\bfrom=.$pb.+PresVer2/s, "$pa gets $pb presence");
 
     $pa->send_xml(qq{<presence><status>PresVer3</status></presence>});
+	$pa->recv_xml;
     $xml = $pb->recv_xml;
     like($xml, qr/<presence.+\bfrom=.$pa.+PresVer3/s, "$pb gets $pa presencs");
 

--- a/t/write-error-and-close.t
+++ b/t/write-error-and-close.t
@@ -15,7 +15,9 @@ two_parties_one_server(sub {
 
     # now pa/pb send presence to become available resources
     $pa->send_xml("<presence/>");
+	$pa->recv_xml;
     $pb->send_xml("<presence/>");
+	$pb->recv_xml;
 
     # add ourself to our roster, so when we die, the server will send
     # us our own disconnect info, causing infinite recursion if server

--- a/t/xmlnamespace.t
+++ b/t/xmlnamespace.t
@@ -12,7 +12,9 @@ two_parties(sub {
 
     # now pa/pb send presence to become available resources
     $pa->send_xml("<presence/>");
+	$pa->recv_xml;
     $pb->send_xml("<presence/>");
+	$pb->recv_xml;
     select(undef, undef, undef, 0.25);
 
     # PA to PB


### PR DESCRIPTION
Some final fixes for functionality and to align codebase with latest RFC6121/XEPs revision

- Forms - for type `submit` field `type` attribute is not mandatory, for type `cancel` nothing is mandatory
- Presence - an entity is implicitly subscribed to its own presence (fix Presence and tests)
- Hook ordering - fix before/after-ALL case
- Namespace - Fix s2s namespace as suggested by #4 and avoid polluting namespace by passing ns_map by value

Enhancement: Make AlterPresenceAvailable/Unavailable a signal by ordering storage plugin as the last (after ALL) and allowing fallthrough by catching fallback.